### PR TITLE
Add flight segment support and client autocomplete

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -22,6 +22,7 @@ const AppState = {
   isConnected: false,
   user: null,
   notifications: [],
+  clientes: [],
   
   // Datos de la venta actual
   currentSale: {
@@ -262,6 +263,7 @@ class NTSApp {
     try {
       if (AppState.isConnected) {
         await this.loadDashboardData();
+        await this.loadClientes();
       } else {
         this.loadMockData();
       }
@@ -363,6 +365,50 @@ class NTSApp {
     if (window.lucide) {
       window.lucide.createIcons();
     }
+  }
+
+  async loadClientes() {
+    try {
+      if (!AppState.isConnected) return;
+      const { data, error } = await AppState.supabase
+        .from('clientes')
+        .select('id, nombre, email, telefono')
+        .order('nombre');
+      if (error) throw error;
+      AppState.clientes = data || [];
+      this.setupClientAutocomplete();
+    } catch (error) {
+      console.error('Error cargando clientes:', error);
+    }
+  }
+
+  setupClientAutocomplete() {
+    const input = document.getElementById('cliente-nombre');
+    if (!input) return;
+
+    let datalist = document.getElementById('clientes-datalist');
+    if (!datalist) {
+      datalist = document.createElement('datalist');
+      datalist.id = 'clientes-datalist';
+      document.body.appendChild(datalist);
+    }
+
+    datalist.innerHTML = AppState.clientes
+      .map(c => `<option value="${c.nombre}" data-id="${c.id}" data-email="${c.email || ''}" data-telefono="${c.telefono || ''}"></option>`)
+      .join('');
+
+    input.setAttribute('list', 'clientes-datalist');
+
+    input.addEventListener('input', function () {
+      const option = [...datalist.options].find(o => o.value.toLowerCase() === this.value.toLowerCase());
+      if (option) {
+        const emailField = document.getElementById('cliente-email');
+        const telField = document.getElementById('cliente-telefono');
+        if (emailField) emailField.value = option.dataset.email;
+        if (telField) telField.value = option.dataset.telefono;
+        AppState.currentSale.client.id = option.dataset.id;
+      }
+    });
   }
 
   loadMockActivity() {
@@ -562,6 +608,7 @@ class NTSApp {
     
     // Guardar datos del cliente
     AppState.currentSale.client = {
+      ...AppState.currentSale.client,
       nombre: nombre,
       email: document.getElementById('cliente-email')?.value?.trim(),
       telefono: document.getElementById('cliente-telefono')?.value?.trim(),
@@ -662,17 +709,24 @@ class NTSApp {
               <label for="vuelo-pasajeros">Pasajeros</label>
               <input type="number" id="vuelo-pasajeros" class="form-control" value="1" min="1">
             </div>
-            <div class="form-group">
-              <label for="vuelo-aerolinea">Aerolínea</label>
-              <input type="text" id="vuelo-aerolinea" class="form-control" placeholder="American Airlines">
-            </div>
+          <div class="form-group">
+            <label for="vuelo-aerolinea">Aerolínea</label>
+            <input type="text" id="vuelo-aerolinea" class="form-control" placeholder="American Airlines">
           </div>
-          <div class="form-actions" style="margin-top: var(--spacing-lg);">
-            <button type="button" class="btn btn-primary" onclick="app.addService('vuelo')">
-              <i data-lucide="plus"></i>
-              Agregar Vuelo
+          <div class="form-group full-width">
+            <label><strong>Tramos del Vuelo</strong></label>
+            <div id="segments-container"></div>
+            <button type="button" class="btn btn-secondary" id="add-segment-btn" style="margin-top: var(--spacing-sm);">
+              Agregar tramo
             </button>
           </div>
+        </div>
+        <div class="form-actions" style="margin-top: var(--spacing-lg);">
+          <button type="button" class="btn btn-primary" onclick="app.addService('vuelo')">
+            <i data-lucide="plus"></i>
+            Agregar Vuelo
+          </button>
+        </div>
         </div>
       </div>
     `;
@@ -811,8 +865,43 @@ class NTSApp {
   }
 
   setupServiceFormEvents(serviceType) {
-    // Aquí se pueden agregar eventos específicos para cada tipo de servicio
+    // Eventos específicos por tipo de servicio
     console.log(`Configurando eventos para servicio: ${serviceType}`);
+    if (serviceType === 'vuelo') {
+      const container = document.getElementById('segments-container');
+      const addBtn = document.getElementById('add-segment-btn');
+      if (!container || !addBtn) return;
+
+      const addSegment = () => {
+        container.appendChild(this.createSegmentRow());
+      };
+
+      addBtn.addEventListener('click', addSegment);
+      addSegment();
+
+      container.addEventListener('click', (e) => {
+        if (e.target.classList.contains('remove-segment')) {
+          e.target.closest('.segment-row')?.remove();
+        }
+      });
+    }
+  }
+
+  createSegmentRow() {
+    const row = document.createElement('div');
+    row.className = 'segment-row';
+    row.style.display = 'grid';
+    row.style.gridTemplateColumns = 'repeat(4, 1fr) auto';
+    row.style.gap = 'var(--spacing-sm)';
+    row.style.marginBottom = 'var(--spacing-sm)';
+    row.innerHTML = `
+      <input type="text" class="form-control segment-origen" placeholder="Origen">
+      <input type="text" class="form-control segment-destino" placeholder="Destino">
+      <input type="datetime-local" class="form-control segment-salida">
+      <input type="datetime-local" class="form-control segment-llegada">
+      <button type="button" class="btn btn-danger remove-segment">&times;</button>
+    `;
+    return row;
   }
 
   addService(serviceType) {
@@ -842,13 +931,22 @@ class NTSApp {
     
     switch (serviceType) {
       case 'vuelo':
+        const segmentRows = document.querySelectorAll('#segments-container .segment-row');
+        const segmentos = Array.from(segmentRows).map((row, index) => ({
+          numero_segmento: index + 1,
+          aeropuerto_origen: row.querySelector('.segment-origen')?.value?.trim(),
+          aeropuerto_destino: row.querySelector('.segment-destino')?.value?.trim(),
+          fecha_hora_salida_local: row.querySelector('.segment-salida')?.value || null,
+          fecha_hora_llegada_local: row.querySelector('.segment-llegada')?.value || null
+        }));
         return {
           ...baseData,
           origen: document.getElementById('vuelo-origen')?.value?.trim(),
           destino: document.getElementById('vuelo-destino')?.value?.trim(),
           fecha: document.getElementById('vuelo-fecha')?.value,
           pasajeros: parseInt(document.getElementById('vuelo-pasajeros')?.value) || 1,
-          aerolinea: document.getElementById('vuelo-aerolinea')?.value?.trim()
+          aerolinea: document.getElementById('vuelo-aerolinea')?.value?.trim(),
+          segmentos
         };
       case 'hotel':
         return {
@@ -893,6 +991,15 @@ class NTSApp {
       case 'vuelo':
         if (!serviceData.origen || !serviceData.destino) {
           this.showNotification('Por favor complete origen y destino del vuelo', 'warning');
+          return false;
+        }
+        if (!serviceData.segmentos || serviceData.segmentos.length === 0) {
+          this.showNotification('Agregue al menos un tramo de vuelo', 'warning');
+          return false;
+        }
+        const invalid = serviceData.segmentos.some(s => !s.aeropuerto_origen || !s.aeropuerto_destino);
+        if (invalid) {
+          this.showNotification('Complete origen y destino en todos los tramos', 'warning');
           return false;
         }
         break;
@@ -1025,6 +1132,14 @@ class NTSApp {
         input.value = '';
       }
     });
+
+    if (serviceType === 'vuelo') {
+      const container = document.getElementById('segments-container');
+      if (container) {
+        container.innerHTML = '';
+        container.appendChild(this.createSegmentRow());
+      }
+    }
   }
 
   // ===== ACCIONES PRINCIPALES =====
@@ -1098,9 +1213,68 @@ class NTSApp {
   }
 
   async createSaleInDB(saleData) {
-    // Implementar creación en Supabase
+    if (!AppState.supabase) return;
     console.log('Creando venta en DB:', saleData);
-    // Por ahora solo log, implementar según estructura de DB
+    const { data: venta, error: ventaError } = await AppState.supabase
+      .from('ventas')
+      .insert({
+        numero_venta: saleData.numero_venta,
+        cliente_id: saleData.cliente.id || null,
+        fecha_viaje_inicio: saleData.viaje.fechaInicio || null,
+        fecha_viaje_fin: saleData.viaje.fechaFin || null,
+        observaciones: saleData.viaje.observaciones || null,
+        total_final: saleData.totales.total,
+        estado: saleData.estado,
+        estado_pago: saleData.estado_pago
+      })
+      .select()
+      .single();
+
+    if (ventaError) {
+      console.error('Error creando venta:', ventaError);
+      throw ventaError;
+    }
+
+    for (const servicio of saleData.servicios) {
+      if (servicio.type === 'vuelo') {
+        const { data: vuelo, error: vueloError } = await AppState.supabase
+          .from('venta_vuelos')
+          .insert({
+            venta_id: venta.id,
+            origen: servicio.origen,
+            destino: servicio.destino,
+            fecha: servicio.fecha,
+            pasajeros: servicio.pasajeros,
+            aerolinea: servicio.aerolinea,
+            precio: servicio.precio
+          })
+          .select()
+          .single();
+
+        if (vueloError) {
+          console.error('Error creando vuelo:', vueloError);
+          throw vueloError;
+        }
+
+        if (servicio.segmentos && servicio.segmentos.length) {
+          const segmentos = servicio.segmentos.map(seg => ({
+            venta_vuelo_id: vuelo.id,
+            numero_segmento: seg.numero_segmento,
+            aeropuerto_origen: seg.aeropuerto_origen,
+            aeropuerto_destino: seg.aeropuerto_destino,
+            fecha_hora_salida_local: seg.fecha_hora_salida_local,
+            fecha_hora_llegada_local: seg.fecha_hora_llegada_local
+          }));
+          const { error: segError } = await AppState.supabase
+            .from('venta_vuelo_segmentos')
+            .insert(segmentos);
+          if (segError) {
+            console.error('Error creando segmentos:', segError);
+            throw segError;
+          }
+        }
+      }
+    }
   }
 
   createSaleLocally(saleData) {


### PR DESCRIPTION
## Summary
- Allow adding multiple flight segments in sales form and persist them when saving to Supabase
- Load clients from database and provide autocomplete by name
- Query Spanish `clientes` table and retain selected client ID when validating the form

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b13e9ca88328a214695fec5625ea