### PR TITLE
Refactor escala handling into Ventas module

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,7 @@
 // ===== MAIN.JS - APLICACIÓN PRINCIPAL NTS V2.0 =====
 
+import { addEscalaRow, removeEscalaRow } from './modules/ventas.js';
+
 console.log('🚀 Iniciando NTS Sistema v2.0...');
 
 // ===== CONFIGURACIÓN GLOBAL =====
@@ -873,7 +875,7 @@ class NTSApp {
       if (!container || !addBtn) return;
 
       const addSegment = () => {
-        container.appendChild(this.createSegmentRow());
+        addEscalaRow(container);
       };
 
       addBtn.addEventListener('click', addSegment);
@@ -881,28 +883,12 @@ class NTSApp {
 
       container.addEventListener('click', (e) => {
         if (e.target.classList.contains('remove-segment')) {
-          e.target.closest('.segment-row')?.remove();
+          removeEscalaRow(e.target);
         }
       });
     }
   }
 
-  createSegmentRow() {
-    const row = document.createElement('div');
-    row.className = 'segment-row';
-    row.style.display = 'grid';
-    row.style.gridTemplateColumns = 'repeat(4, 1fr) auto';
-    row.style.gap = 'var(--spacing-sm)';
-    row.style.marginBottom = 'var(--spacing-sm)';
-    row.innerHTML = `
-      <input type="text" class="form-control segment-origen" placeholder="Origen">
-      <input type="text" class="form-control segment-destino" placeholder="Destino">
-      <input type="datetime-local" class="form-control segment-salida">
-      <input type="datetime-local" class="form-control segment-llegada">
-      <button type="button" class="btn btn-danger remove-segment">&times;</button>
-    `;
-    return row;
-  }
 
   addService(serviceType) {
     const serviceData = this.getServiceData(serviceType);
@@ -1137,7 +1123,7 @@ class NTSApp {
       const container = document.getElementById('segments-container');
       if (container) {
         container.innerHTML = '';
-        container.appendChild(this.createSegmentRow());
+        addEscalaRow(container);
       }
     }
   }

--- a/js/modules/ventas.js
+++ b/js/modules/ventas.js
@@ -542,6 +542,39 @@ function calculateMargin(element) {
     }
 }
 
+// ===== ESCALAS / SEGMENTOS =====
+export function toggleEscalasSection(show) {
+    const section = document.getElementById('segments-container');
+    if (!section) return;
+    section.style.display = show ? 'block' : 'none';
+}
+
+export function addEscalaRow(container) {
+    if (!container) return;
+    container.appendChild(createEscalaRow());
+}
+
+export function removeEscalaRow(element) {
+    element.closest('.segment-row')?.remove();
+}
+
+function createEscalaRow() {
+    const row = document.createElement('div');
+    row.className = 'segment-row';
+    row.style.display = 'grid';
+    row.style.gridTemplateColumns = 'repeat(4, 1fr) auto';
+    row.style.gap = 'var(--spacing-sm)';
+    row.style.marginBottom = 'var(--spacing-sm)';
+    row.innerHTML = `
+        <input type="text" class="form-control segment-origen" placeholder="Origen">
+        <input type="text" class="form-control segment-destino" placeholder="Destino">
+        <input type="datetime-local" class="form-control segment-salida">
+        <input type="datetime-local" class="form-control segment-llegada">
+        <button type="button" class="btn btn-danger remove-segment">&times;</button>
+    `;
+    return row;
+}
+
 // ===== AGREGAR SERVICIOS =====
 function agregarServicioMejorado(tipo) {
     console.log(`➕ Agregando servicio: ${tipo}`);


### PR DESCRIPTION
## Summary
- centralize escala/segment helpers inside `modules/ventas.js`
- update main app to import these helpers instead of defining duplicates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a12977ee748328a7c6b4b81ad06787