### PR TITLE
refactor: centralize supabase config

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,5 @@
+import './config.js';
+
 // ===== MAIN.JS - APLICACIÓN PRINCIPAL NTS V2.0 =====
 
 console.log('🚀 Iniciando NTS Sistema v2.0...');
@@ -6,11 +8,7 @@ console.log('🚀 Iniciando NTS Sistema v2.0...');
 const APP_CONFIG = {
   name: 'NTS Sistema',
   version: '2.0.0',
-  debug: true,
-  supabase: {
-    url: 'https://fmvozdsvpxitoyhtdmcv.supabase.co',
-    key: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZtdm96ZHN2cHhpdG95aHRkbWN2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUyMjc1MzEsImV4cCI6MjA3MDgwMzUzMX0.EqK3pND6Zz48OpnVDCF_0KJUcV3TzkRUz9qTMWL3NNE'
-  }
+  debug: true
 };
 
 // ===== ESTADO GLOBAL =====
@@ -80,20 +78,13 @@ class NTSApp {
 
   async initSupabase() {
     try {
-      if (typeof window.supabase !== 'undefined') {
-        AppState.supabase = window.supabase.createClient(
-          APP_CONFIG.supabase.url,
-          APP_CONFIG.supabase.key
-        );
-        
-        // Test connection
-        const { data, error } = await AppState.supabase.auth.getSession();
-        
-        if (!error || error.message.includes('session_not_found')) {
-          AppState.isConnected = true;
-          console.log('✅ Supabase conectado');
-          this.updateConnectionStatus(true);
-        }
+      const { supabase, isSupabaseConnected } = window.NTS_CONFIG || {};
+
+      if (supabase) {
+        AppState.supabase = supabase;
+        AppState.isConnected = !!isSupabaseConnected;
+        console.log(AppState.isConnected ? '✅ Supabase conectado' : '⚠️ Supabase no disponible');
+        this.updateConnectionStatus(AppState.isConnected);
       } else {
         console.log('⚠️ Supabase no disponible');
         this.updateConnectionStatus(false);

--- a/js/modules/ventas.js
+++ b/js/modules/ventas.js
@@ -1,6 +1,8 @@
 // 💰 MÓDULO DE VENTAS - VERSIÓN COMPLETA SIN DUPLICADOS
 // Archivo: js/modules/ventas.js
 
+import '../config.js';
+
 console.log('💰 Cargando módulo de ventas (versión sin duplicados)...');
 
 // ===== ESTADO DEL MÓDULO =====


### PR DESCRIPTION
## Summary
- centralize Supabase credentials in `js/config.js`
- reuse single Supabase client in `js/main.js` and `js/modules/ventas.js`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f268847c832886eb5a9005ab577e