### PR TITLE
Enable full sale editing with service and segment updates

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1059,3 +1059,189 @@ body {
 ::-webkit-scrollbar-thumb:hover {
   background: var(--gray-400);
 }
+
+/* ===== ESTILOS ADICIONALES PARA ESCALAS Y BÚSQUEDA DE CLIENTES ===== */
+/* Estilos para checkbox de escalas */
+.checkbox-container {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.checkbox-container input[type="checkbox"] {
+  width: 1.25rem;
+  height: 1.25rem;
+  accent-color: var(--primary-500);
+}
+
+/* Estilos para búsqueda de clientes */
+.search-result-item {
+  padding: 0.75rem;
+  border-bottom: 1px solid var(--gray-100);
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transition: background-color 0.15s ease;
+}
+
+.search-result-item:hover {
+  background-color: var(--primary-50);
+}
+
+.search-result-item:last-child {
+  border-bottom: none;
+}
+
+.cliente-info {
+  flex: 1;
+}
+
+.cliente-nombre {
+  font-weight: 500;
+  color: var(--gray-900);
+  margin-bottom: 0.25rem;
+}
+
+.cliente-detalles {
+  font-size: 0.875rem;
+  color: var(--gray-600);
+  display: flex;
+  gap: 1rem;
+}
+
+.status-badge {
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.status-badge.existing {
+  background-color: var(--success-500);
+  color: white;
+}
+
+.no-results {
+  text-align: center;
+  padding: 1rem;
+  color: var(--gray-500);
+}
+
+.no-results-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+mark {
+  background-color: #ffeb3b;
+  padding: 0;
+  border-radius: 2px;
+}
+
+/* Estilos para segmentos de vuelo */
+.segment-row {
+  animation: slideIn 0.3s ease;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  padding: 1rem;
+  border: 1px solid var(--gray-200);
+  border-radius: 0.5rem;
+  background: var(--gray-50);
+}
+
+.escalas-section {
+  margin-top: 0.5rem;
+  border-top: 1px dashed var(--gray-200);
+  padding-top: 0.5rem;
+  grid-column: 1 / -1;
+}
+
+.escalas-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.escala-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border: 1px dashed var(--gray-200);
+  border-radius: 0.5rem;
+  background: var(--gray-50);
+  width: 100%;
+}
+
+.escala-row .form-group:last-child {
+  display: flex;
+  align-items: flex-end;
+}
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.btn-danger {
+  background-color: var(--error-500);
+  color: white;
+  border: 1px solid var(--error-500);
+}
+
+.btn-danger:hover {
+  background-color: #dc2626;
+  border-color: #dc2626;
+}
+
+/* ===== Tablas ===== */
+.table-actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.table-container {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 0.75rem;
+  border-bottom: 1px solid var(--gray-200);
+  text-align: left;
+}
+
+.table th {
+  background: var(--gray-50);
+  font-weight: 600;
+}
+
+.table-row-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.service-actions {
+  display: flex;
+  gap: 0.25rem;
+}

--- a/index.html
+++ b/index.html
@@ -328,8 +328,38 @@
                                     </div>
                                     
                                     <div class="form-group">
-                                        <label for="cliente-documento">DNI/Pasaporte</label>
-                                        <input type="text" id="cliente-documento" class="form-control" placeholder="12345678">
+                                        <label for="cliente-doc-tipo">Tipo de Documento</label>
+                                        <select id="cliente-doc-tipo" class="form-control">
+                                            <option value="dni">DNI</option>
+                                            <option value="pasaporte">Pasaporte</option>
+                                        </select>
+                                    </div>
+
+                                    <div class="form-group" id="grupo-dni">
+                                        <label for="cliente-dni">DNI</label>
+                                        <input type="text" id="cliente-dni" class="form-control" placeholder="12345678">
+                                    </div>
+
+                                    <div class="form-group" id="grupo-dni-exp">
+                                        <label for="cliente-dni-expiracion">Vencimiento DNI</label>
+                                        <input type="date" id="cliente-dni-expiracion" class="form-control">
+                                    </div>
+
+                                    <div class="form-group hidden" id="grupo-pasaporte">
+                                        <label for="cliente-pasaporte">Pasaporte</label>
+                                        <input type="text" id="cliente-pasaporte" class="form-control" placeholder="AB123456">
+                                    </div>
+
+                                    <div class="form-group hidden" id="grupo-pasaporte-exp">
+                                        <label for="cliente-pasaporte-expiracion">Vencimiento Pasaporte</label>
+                                        <input type="date" id="cliente-pasaporte-expiracion" class="form-control">
+                                    </div>
+
+                                    <div class="form-group">
+                                        <label for="vendedor-select-nts"><strong>Vendedor Responsable *</strong></label>
+                                        <select id="vendedor-select-nts" class="form-control" required>
+                                            <option value="">Seleccionar vendedor...</option>
+                                        </select>
                                     </div>
                                 </div>
                             </div>
@@ -348,15 +378,20 @@
                             <div class="card-content">
                                 <div class="form-grid">
                                     <div class="form-group">
+                                        <label for="fecha-venta">Fecha de Venta *</label>
+                                        <input type="date" id="fecha-venta" class="form-control" required>
+                                    </div>
+
+                                    <div class="form-group">
                                         <label for="fecha-viaje-inicio">Fecha de Inicio *</label>
                                         <input type="date" id="fecha-viaje-inicio" class="form-control" required>
                                     </div>
-                                    
+
                                     <div class="form-group">
                                         <label for="fecha-viaje-fin">Fecha de Fin</label>
                                         <input type="date" id="fecha-viaje-fin" class="form-control">
                                     </div>
-                                    
+
                                     <div class="form-group full-width">
                                         <label for="observaciones-venta">Observaciones del Viaje</label>
                                         <textarea id="observaciones-venta" class="form-control" rows="4" placeholder="Detalles especiales, notas importantes, comentarios del cliente..."></textarea>
@@ -470,10 +505,32 @@
                         <p>Administrar todas las ventas</p>
                     </div>
                 </div>
-                <div class="coming-soon">
-                    <i data-lucide="construction"></i>
-                    <h3>Próximamente</h3>
-                    <p>Esta sección está en desarrollo</p>
+                <div class="table-actions">
+                    <input type="text" id="ventas-search" class="form-control" placeholder="Buscar ventas...">
+                    <input list="ventas-clientes" id="ventas-cliente" class="form-control" placeholder="Filtrar por cliente">
+                    <datalist id="ventas-clientes"></datalist>
+                    <select id="ventas-filter" class="form-control">
+                        <option value="">Todos los estados</option>
+                        <option value="pendiente">Pendiente</option>
+                        <option value="confirmada">Confirmada</option>
+                        <option value="cancelada">Cancelada</option>
+                        <option value="finalizada">Finalizada</option>
+                    </select>
+                </div>
+                <div class="table-container">
+                    <table id="ventas-table" class="table">
+                        <thead>
+                            <tr>
+                                <th>#</th>
+                                <th>Cliente</th>
+                                <th>Fecha</th>
+                                <th>Total</th>
+                                <th>Estado</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
                 </div>
             </section>
 

--- a/js/main.js
+++ b/js/main.js
@@ -23,7 +23,9 @@ const AppState = {
   user: null,
   notifications: [],
   clientes: [],
-  
+  vendedores: [],
+  ventas: [],
+
   // Datos de la venta actual
   currentSale: {
     client: {},
@@ -33,13 +35,17 @@ const AppState = {
       subtotal: 0,
       discounts: 0,
       total: 0
-    }
-  }
+    },
+    fechaVenta: null
+  },
+  editingSaleId: null,
+  editingServiceId: null
 };
 
 // ===== INICIALIZACIÓN =====
 class NTSApp {
   constructor() {
+    this.ventasListenersSetup = false;
     this.init();
   }
 
@@ -112,10 +118,13 @@ class NTSApp {
     
     // Configurar formulario de pasos
     this.setupStepForm();
-    
+
     // Configurar servicios
     this.setupServices();
-    
+
+    // Configurar toggle de documentos
+    this.setupDocumentoToggle();
+
     // Configurar header actions
     this.setupHeaderActions();
   }
@@ -175,6 +184,22 @@ class NTSApp {
     if (settingsBtn) {
       settingsBtn.addEventListener('click', () => this.showSettingsPanel());
     }
+  }
+
+  setupDocumentoToggle() {
+    const select = document.getElementById('cliente-doc-tipo');
+    if (!select) return;
+    select.addEventListener('change', () => this.toggleDocumentoFields());
+    this.toggleDocumentoFields();
+  }
+
+  toggleDocumentoFields() {
+    const tipo = document.getElementById('cliente-doc-tipo')?.value || 'dni';
+    const isDNI = tipo === 'dni';
+    document.getElementById('grupo-dni')?.classList.toggle('hidden', !isDNI);
+    document.getElementById('grupo-dni-exp')?.classList.toggle('hidden', !isDNI);
+    document.getElementById('grupo-pasaporte')?.classList.toggle('hidden', isDNI);
+    document.getElementById('grupo-pasaporte-exp')?.classList.toggle('hidden', isDNI);
   }
 
   setupEventListeners() {
@@ -264,6 +289,7 @@ class NTSApp {
       if (AppState.isConnected) {
         await this.loadDashboardData();
         await this.loadClientes();
+        await this.loadVendedores();
       } else {
         this.loadMockData();
       }
@@ -324,6 +350,12 @@ class NTSApp {
     
     this.loadMockActivity();
     this.initSalesChart();
+
+    AppState.vendedores = [
+      { id: 1, nombre: 'Ana García', codigo_vendedor: 'V001', rol: 'gerente' },
+      { id: 2, nombre: 'Carlos López', codigo_vendedor: 'V002', rol: 'vendedor' }
+    ];
+    this.populateVendedorSelect();
   }
 
   updateDashboardStats(stats) {
@@ -408,6 +440,33 @@ class NTSApp {
         if (telField) telField.value = option.dataset.telefono;
         AppState.currentSale.client.id = option.dataset.id;
       }
+    });
+  }
+
+  async loadVendedores() {
+    try {
+      if (!AppState.isConnected) return;
+      const { data, error } = await AppState.supabase
+        .from('vendedores')
+        .select('id, nombre, codigo_vendedor, rol')
+        .order('nombre');
+      if (error) throw error;
+      AppState.vendedores = data || [];
+      this.populateVendedorSelect();
+    } catch (error) {
+      console.error('Error cargando vendedores:', error);
+    }
+  }
+
+  populateVendedorSelect() {
+    const select = document.getElementById('vendedor-select-nts');
+    if (!select) return;
+    select.innerHTML = '<option value="">Seleccionar vendedor...</option>';
+    AppState.vendedores.forEach(v => {
+      const option = document.createElement('option');
+      option.value = v.id;
+      option.textContent = `${v.nombre} (${v.codigo_vendedor}) - ${v.rol}`;
+      select.appendChild(option);
     });
   }
 
@@ -529,6 +588,9 @@ class NTSApp {
       case 'nueva-venta':
         this.initNewSaleForm();
         break;
+      case 'ventas':
+        this.loadVentasList();
+        break;
       default:
         console.log(`Pestaña ${tabName} no implementada aún`);
     }
@@ -599,41 +661,68 @@ class NTSApp {
 
   validateClientStep() {
     const nombre = document.getElementById('cliente-nombre')?.value?.trim();
-    
+    const docTipo = document.getElementById('cliente-doc-tipo')?.value;
+    const dni = document.getElementById('cliente-dni')?.value?.trim();
+    const pasaporte = document.getElementById('cliente-pasaporte')?.value?.trim();
+
     if (!nombre) {
       this.showNotification('Por favor ingrese el nombre del cliente', 'warning');
       document.getElementById('cliente-nombre')?.focus();
       return false;
     }
-    
+
+    if (docTipo === 'dni' && !dni) {
+      this.showNotification('Por favor ingrese el DNI del cliente', 'warning');
+      document.getElementById('cliente-dni')?.focus();
+      return false;
+    }
+
+    if (docTipo === 'pasaporte' && !pasaporte) {
+      this.showNotification('Por favor ingrese el pasaporte del cliente', 'warning');
+      document.getElementById('cliente-pasaporte')?.focus();
+      return false;
+    }
+
     // Guardar datos del cliente
     AppState.currentSale.client = {
       ...AppState.currentSale.client,
       nombre: nombre,
       email: document.getElementById('cliente-email')?.value?.trim(),
       telefono: document.getElementById('cliente-telefono')?.value?.trim(),
-      documento: document.getElementById('cliente-documento')?.value?.trim()
+      dni: docTipo === 'dni' ? dni : null,
+      pasaporte: docTipo === 'pasaporte' ? pasaporte : null,
+      dni_expiracion: docTipo === 'dni' ? document.getElementById('cliente-dni-expiracion')?.value : null,
+      pasaporte_expiracion: docTipo === 'pasaporte' ? document.getElementById('cliente-pasaporte-expiracion')?.value : null,
+      documento_tipo: docTipo
     };
-    
+
     return true;
   }
 
   validateTripStep() {
+    const fechaVenta = document.getElementById('fecha-venta')?.value;
     const fechaInicio = document.getElementById('fecha-viaje-inicio')?.value;
-    
+
+    if (!fechaVenta) {
+      this.showNotification('Por favor seleccione la fecha de venta', 'warning');
+      document.getElementById('fecha-venta')?.focus();
+      return false;
+    }
+
     if (!fechaInicio) {
       this.showNotification('Por favor seleccione la fecha de inicio del viaje', 'warning');
       document.getElementById('fecha-viaje-inicio')?.focus();
       return false;
     }
-    
-    // Guardar datos del viaje
+
+    // Guardar datos del viaje y venta
+    AppState.currentSale.fechaVenta = fechaVenta;
     AppState.currentSale.trip = {
       fechaInicio: fechaInicio,
       fechaFin: document.getElementById('fecha-viaje-fin')?.value,
       observaciones: document.getElementById('observaciones-venta')?.value?.trim()
     };
-    
+
     return true;
   }
 
@@ -690,43 +779,43 @@ class NTSApp {
         <div class="card-content">
           <div class="form-grid">
             <div class="form-group">
-              <label for="vuelo-origen">Origen *</label>
-              <input type="text" id="vuelo-origen" class="form-control" placeholder="Buenos Aires (BUE)" required>
-            </div>
-            <div class="form-group">
-              <label for="vuelo-destino">Destino *</label>
-              <input type="text" id="vuelo-destino" class="form-control" placeholder="Miami (MIA)" required>
-            </div>
-            <div class="form-group">
-              <label for="vuelo-fecha">Fecha de Salida *</label>
-              <input type="date" id="vuelo-fecha" class="form-control" required>
-            </div>
-            <div class="form-group">
-              <label for="vuelo-precio">Precio *</label>
-              <input type="number" id="vuelo-precio" class="form-control" placeholder="1500" step="0.01" min="0" required>
+              <label for="vuelo-itinerario">Tipo de itinerario *</label>
+              <select id="vuelo-itinerario" class="form-control" required>
+                <option value="ida_vuelta">Ida y vuelta</option>
+                <option value="ida">Ida</option>
+                <option value="multitramo">Multitramo</option>
+                <option value="stopover">Stopover</option>
+              </select>
             </div>
             <div class="form-group">
               <label for="vuelo-pasajeros">Pasajeros</label>
               <input type="number" id="vuelo-pasajeros" class="form-control" value="1" min="1">
             </div>
-          <div class="form-group">
-            <label for="vuelo-aerolinea">Aerolínea</label>
-            <input type="text" id="vuelo-aerolinea" class="form-control" placeholder="American Airlines">
+            <div class="form-group">
+              <label for="vuelo-costo">Costo</label>
+              <input type="number" id="vuelo-costo" class="form-control" step="0.01" min="0">
+            </div>
+            <div class="form-group">
+              <label for="vuelo-precio">Precio de venta *</label>
+              <input type="number" id="vuelo-precio" class="form-control" step="0.01" min="0" required>
+            </div>
           </div>
-          <div class="form-group full-width">
-            <label><strong>Tramos del Vuelo</strong></label>
+
+          <div class="form-section" style="margin-top: 1rem;">
+            <h4>Segmentos del vuelo</h4>
             <div id="segments-container"></div>
-            <button type="button" class="btn btn-secondary" id="add-segment-btn" style="margin-top: var(--spacing-sm);">
+            <button type="button" class="btn btn-secondary" id="add-segment-btn" style="margin-top: 0.5rem;">
+              <i data-lucide="plus"></i>
               Agregar tramo
             </button>
           </div>
-        </div>
-        <div class="form-actions" style="margin-top: var(--spacing-lg);">
-          <button type="button" class="btn btn-primary" onclick="app.addService('vuelo')">
-            <i data-lucide="plus"></i>
-            Agregar Vuelo
-          </button>
-        </div>
+
+          <div class="form-actions" style="margin-top: 1.5rem;">
+            <button type="button" class="btn btn-primary" onclick="app.addService('vuelo')">
+              <i data-lucide="plus"></i>
+              Agregar Vuelo
+            </button>
+          </div>
         </div>
       </div>
     `;
@@ -869,83 +958,100 @@ class NTSApp {
     console.log(`Configurando eventos para servicio: ${serviceType}`);
     if (serviceType === 'vuelo') {
       const container = document.getElementById('segments-container');
-      const addBtn = document.getElementById('add-segment-btn');
-      if (!container || !addBtn) return;
-
-      const addSegment = () => {
-        container.appendChild(this.createSegmentRow());
-      };
-
-      addBtn.addEventListener('click', addSegment);
-      addSegment();
-
-      container.addEventListener('click', (e) => {
-        if (e.target.classList.contains('remove-segment')) {
-          e.target.closest('.segment-row')?.remove();
-        }
-      });
+      if (container && !container.children.length) {
+        addSegmentRow();
+      }
     }
-  }
-
-  createSegmentRow() {
-    const row = document.createElement('div');
-    row.className = 'segment-row';
-    row.style.display = 'grid';
-    row.style.gridTemplateColumns = 'repeat(4, 1fr) auto';
-    row.style.gap = 'var(--spacing-sm)';
-    row.style.marginBottom = 'var(--spacing-sm)';
-    row.innerHTML = `
-      <input type="text" class="form-control segment-origen" placeholder="Origen">
-      <input type="text" class="form-control segment-destino" placeholder="Destino">
-      <input type="datetime-local" class="form-control segment-salida">
-      <input type="datetime-local" class="form-control segment-llegada">
-      <button type="button" class="btn btn-danger remove-segment">&times;</button>
-    `;
-    return row;
   }
 
   addService(serviceType) {
     const serviceData = this.getServiceData(serviceType);
-    
+
     if (!this.validateServiceData(serviceData, serviceType)) {
       return;
     }
-    
-    // Agregar servicio al estado
-    serviceData.id = Date.now();
-    serviceData.type = serviceType;
-    AppState.currentSale.services.push(serviceData);
-    
+
+    const isEdit = !!AppState.editingServiceId;
+    if (isEdit) {
+      const idx = AppState.currentSale.services.findIndex(
+        s => s.id === AppState.editingServiceId
+      );
+      if (idx !== -1) {
+        AppState.currentSale.services[idx] = {
+          ...serviceData,
+          id: AppState.editingServiceId,
+          type: serviceType
+        };
+      }
+      AppState.editingServiceId = null;
+    } else {
+      serviceData.id = Date.now();
+      serviceData.type = serviceType;
+      AppState.currentSale.services.push(serviceData);
+    }
+
     // Actualizar UI
     this.updateServicesList();
     this.updateTotals();
     this.clearServiceForm(serviceType);
-    
-    this.showNotification(`${serviceType} agregado correctamente`, 'success');
+
+    const btn = document.querySelector('#service-forms .btn.btn-primary');
+    if (btn) {
+      btn.innerHTML = `<i data-lucide="plus"></i> Agregar ${serviceType.charAt(0).toUpperCase() + serviceType.slice(1)}`;
+      if (window.lucide) window.lucide.createIcons();
+    }
+
+    this.showNotification(`${serviceType} ${isEdit ? 'actualizado' : 'agregado'} correctamente`, 'success');
   }
 
   getServiceData(serviceType) {
     const baseData = {
+      costo: parseFloat(document.getElementById(`${serviceType}-costo`)?.value) || 0,
       precio: parseFloat(document.getElementById(`${serviceType}-precio`)?.value) || 0
     };
     
     switch (serviceType) {
       case 'vuelo':
         const segmentRows = document.querySelectorAll('#segments-container .segment-row');
-        const segmentos = Array.from(segmentRows).map((row, index) => ({
-          numero_segmento: index + 1,
-          aeropuerto_origen: row.querySelector('.segment-origen')?.value?.trim(),
-          aeropuerto_destino: row.querySelector('.segment-destino')?.value?.trim(),
-          fecha_hora_salida_local: row.querySelector('.segment-salida')?.value || null,
-          fecha_hora_llegada_local: row.querySelector('.segment-llegada')?.value || null
-        }));
+        const segmentos = Array.from(segmentRows).map((row, index) => {
+          const escalas = Array.from(row.querySelectorAll('.escala-row')).map(er => ({
+            aeropuerto: er.querySelector('.segment-aeropuerto-escala')?.value?.trim(),
+            duracion: er.querySelector('.segment-duracion-escala')?.value?.trim()
+          }));
+          return {
+            numero_segmento: index + 1,
+            aeropuerto_origen: row.querySelector('.segment-origen')?.value?.trim(),
+            aeropuerto_destino: row.querySelector('.segment-destino')?.value?.trim(),
+            aerolinea: row.querySelector('.segment-aerolinea')?.value?.trim(),
+            numero_vuelo: row.querySelector('.segment-numero')?.value?.trim(),
+            fecha_hora_salida_local: row.querySelector('.segment-salida')?.value || null,
+            fecha_hora_llegada_local: row.querySelector('.segment-llegada')?.value || null,
+            tiempo_total_tramo: row.querySelector('.segment-tiempo-total')?.value?.trim() || '',
+            escalas,
+            tiene_escala: escalas.length > 0
+          };
+        });
+        const origen = segmentos[0]?.aeropuerto_origen || '';
+        const destino = segmentos[segmentos.length - 1]?.aeropuerto_destino || '';
+        const tieneEscalas = segmentos.some(s => s.tiene_escala);
+        const cantidad_escalas = segmentos.reduce(
+          (sum, s) => sum + (s.escalas ? s.escalas.length : 0),
+          0
+        );
+        const descripcion = origen && destino ? `Vuelo ${origen} → ${destino}` : 'Vuelo';
+        const tipo_itinerario =
+          document.getElementById('vuelo-itinerario')?.value || 'ida_vuelta';
+
         return {
           ...baseData,
-          origen: document.getElementById('vuelo-origen')?.value?.trim(),
-          destino: document.getElementById('vuelo-destino')?.value?.trim(),
-          fecha: document.getElementById('vuelo-fecha')?.value,
           pasajeros: parseInt(document.getElementById('vuelo-pasajeros')?.value) || 1,
-          aerolinea: document.getElementById('vuelo-aerolinea')?.value?.trim(),
+          tipo_itinerario,
+          origen,
+          destino,
+          descripcion,
+          tieneEscalas,
+          cantidad_escalas,
+          tiempo_total_vuelo: null,
           segmentos
         };
       case 'hotel':
@@ -989,17 +1095,19 @@ class NTSApp {
     // Validaciones específicas por tipo
     switch (serviceType) {
       case 'vuelo':
-        if (!serviceData.origen || !serviceData.destino) {
-          this.showNotification('Por favor complete origen y destino del vuelo', 'warning');
-          return false;
-        }
         if (!serviceData.segmentos || serviceData.segmentos.length === 0) {
-          this.showNotification('Agregue al menos un tramo de vuelo', 'warning');
+          this.showNotification('Agregue al menos un tramo', 'warning');
           return false;
         }
-        const invalid = serviceData.segmentos.some(s => !s.aeropuerto_origen || !s.aeropuerto_destino);
+
+        const invalid = serviceData.segmentos.some(s => !s.aeropuerto_origen || !s.aeropuerto_destino || !s.aerolinea || !s.numero_vuelo);
         if (invalid) {
-          this.showNotification('Complete origen y destino en todos los tramos', 'warning');
+          this.showNotification('Complete origen, destino, aerolínea y número de vuelo en todos los tramos', 'warning');
+          return false;
+        }
+        const escalaInvalid = serviceData.segmentos.some(s => s.tiene_escala && (s.escalas.length === 0 || s.escalas.some(e => !e.aeropuerto || !e.duracion)));
+        if (escalaInvalid) {
+          this.showNotification('Complete los datos de todas las escalas', 'warning');
           return false;
         }
         break;
@@ -1048,9 +1156,14 @@ class NTSApp {
               <div class="service-title">${description}</div>
               <div class="service-price">${this.formatCurrency(service.precio)}</div>
             </div>
-            <button type="button" class="btn-icon" onclick="app.removeService(${service.id})" title="Eliminar servicio">
-              <i data-lucide="trash-2"></i>
-            </button>
+            <div class="service-actions">
+              <button type="button" class="btn-icon" onclick="app.editService(${service.id})" title="Editar servicio">
+                <i data-lucide="edit"></i>
+              </button>
+              <button type="button" class="btn-icon" onclick="app.removeService(${service.id})" title="Eliminar servicio">
+                <i data-lucide="trash-2"></i>
+              </button>
+            </div>
           </div>
         `;
       }).join('');
@@ -1095,6 +1208,92 @@ class NTSApp {
     this.showNotification('Servicio eliminado', 'info');
   }
 
+  editService(serviceId) {
+    const service = AppState.currentSale.services.find(s => s.id === serviceId);
+    if (!service) return;
+    AppState.editingServiceId = serviceId;
+    this.showServiceTab(service.type);
+    setTimeout(() => {
+      this.populateServiceForm(service);
+      const btn = document.querySelector('#service-forms .btn.btn-primary');
+      if (btn) {
+        btn.innerHTML = '<i data-lucide="check"></i> Guardar servicio';
+        if (window.lucide) window.lucide.createIcons();
+      }
+    });
+  }
+
+  populateServiceForm(service) {
+    switch (service.type) {
+      case 'vuelo': {
+        document.getElementById('vuelo-itinerario').value = service.tipo_itinerario || 'ida_vuelta';
+        document.getElementById('vuelo-pasajeros').value = service.pasajeros || 1;
+        document.getElementById('vuelo-costo').value = service.costo || '';
+        document.getElementById('vuelo-precio').value = service.precio || '';
+        const container = document.getElementById('segments-container');
+        if (container) {
+          container.innerHTML = '';
+          service.segmentos.forEach(seg => {
+            addSegmentRow();
+            const row = container.lastElementChild;
+            row.querySelector('.segment-origen').value = seg.aeropuerto_origen || '';
+            row.querySelector('.segment-destino').value = seg.aeropuerto_destino || '';
+            row.querySelector('.segment-aerolinea').value = seg.aerolinea || '';
+            row.querySelector('.segment-numero').value = seg.numero_vuelo || '';
+            row.querySelector('.segment-salida').value = seg.fecha_hora_salida_local || '';
+            row.querySelector('.segment-llegada').value = seg.fecha_hora_llegada_local || '';
+            row.querySelector('.segment-tiempo-total').value = seg.tiempo_total_tramo || '';
+            if (seg.tiene_escala) {
+              const toggle = row.querySelector('.segment-has-escala');
+              toggle.checked = true;
+              const escalaSection = row.querySelector('.escalas-section');
+              escalaSection.style.display = 'block';
+              const escalaContainer = row.querySelector('.escalas-container');
+              escalaContainer.innerHTML = '';
+              seg.escalas.forEach(es => {
+                addEscalaRowToSegment(row);
+                const escalaRow = escalaContainer.lastElementChild;
+                escalaRow.querySelector('.segment-aeropuerto-escala').value = es.aeropuerto || '';
+                escalaRow.querySelector('.segment-duracion-escala').value = es.duracion || '';
+              });
+            }
+          });
+        }
+        break;
+      }
+      case 'hotel':
+        document.getElementById('hotel-nombre').value = service.nombre || '';
+        document.getElementById('hotel-ciudad').value = service.ciudad || '';
+        document.getElementById('hotel-checkin').value = service.checkin || '';
+        document.getElementById('hotel-checkout').value = service.checkout || '';
+        document.getElementById('hotel-huespedes').value = service.huespedes || 1;
+        const hCosto = document.getElementById('hotel-costo');
+        if (hCosto) hCosto.value = service.costo || '';
+        document.getElementById('hotel-precio').value = service.precio || '';
+        break;
+      case 'traslado':
+        document.getElementById('traslado-origen').value = service.origen || '';
+        document.getElementById('traslado-destino').value = service.destino || '';
+        document.getElementById('traslado-fecha').value = service.fecha || '';
+        document.getElementById('traslado-hora').value = service.hora || '';
+        document.getElementById('traslado-pasajeros').value = service.pasajeros || 1;
+        const tCosto = document.getElementById('traslado-costo');
+        if (tCosto) tCosto.value = service.costo || '';
+        document.getElementById('traslado-precio').value = service.precio || '';
+        break;
+      case 'excursion':
+        document.getElementById('excursion-nombre').value = service.nombre || '';
+        document.getElementById('excursion-destino').value = service.destino || '';
+        document.getElementById('excursion-fecha').value = service.fecha || '';
+        document.getElementById('excursion-duracion').value = service.duracion || '';
+        document.getElementById('excursion-participantes').value = service.participantes || 1;
+        const eCosto = document.getElementById('excursion-costo');
+        if (eCosto) eCosto.value = service.costo || '';
+        document.getElementById('excursion-precio').value = service.precio || '';
+        break;
+    }
+  }
+
   updateTotals() {
     const subtotal = AppState.currentSale.services.reduce((sum, s) => sum + s.precio, 0);
     const descuentos = 0; // Por ahora sin descuentos
@@ -1137,7 +1336,7 @@ class NTSApp {
       const container = document.getElementById('segments-container');
       if (container) {
         container.innerHTML = '';
-        container.appendChild(this.createSegmentRow());
+        addSegmentRow();
       }
     }
   }
@@ -1145,27 +1344,33 @@ class NTSApp {
   // ===== ACCIONES PRINCIPALES =====
   async createSale() {
     try {
-      this.showLoader('Creando venta...');
-      
-      // Validar datos completos
+      this.showLoader(AppState.editingSaleId ? 'Actualizando venta...' : 'Creando venta...');
+
       if (!this.validateSaleData()) {
         this.hideLoader();
         return;
       }
-      
-      // Crear venta
+
       const saleData = this.buildSaleData();
-      
-      if (AppState.isConnected) {
-        await this.createSaleInDB(saleData);
+
+      if (AppState.editingSaleId) {
+        if (AppState.isConnected) {
+          await this.updateSaleInDB(saleData);
+        } else {
+          this.updateSaleLocally(saleData);
+        }
+        this.showNotification('Venta actualizada', 'success');
       } else {
-        this.createSaleLocally(saleData);
+        if (AppState.isConnected) {
+          await this.createSaleInDB(saleData);
+        } else {
+          this.createSaleLocally(saleData);
+        }
+        this.showNotification('Venta creada exitosamente', 'success');
       }
-      
-      this.showNotification('Venta creada exitosamente', 'success');
+
       this.resetSaleForm();
-      this.showTab('dashboard');
-      
+      this.showTab('ventas');
     } catch (error) {
       console.error('Error creando venta:', error);
       this.showNotification('Error al crear la venta', 'error');
@@ -1181,34 +1386,57 @@ class NTSApp {
       this.updateStepForm();
       return false;
     }
-    
+
     if (!AppState.currentSale.trip.fechaInicio) {
       this.showNotification('Faltan datos del viaje', 'warning');
       AppState.currentStep = 2;
       this.updateStepForm();
       return false;
     }
-    
+
+    if (!AppState.currentSale.fechaVenta) {
+      this.showNotification('Falta la fecha de venta', 'warning');
+      AppState.currentStep = 2;
+      this.updateStepForm();
+      return false;
+    }
+
     if (AppState.currentSale.services.length === 0) {
       this.showNotification('Debe agregar al menos un servicio', 'warning');
       AppState.currentStep = 3;
       this.updateStepForm();
       return false;
     }
-    
+
+    const vendedorId = parseInt(document.getElementById('vendedor-select-nts')?.value);
+    if (!vendedorId) {
+      this.showNotification('Falta seleccionar el vendedor responsable', 'warning');
+      AppState.currentStep = 1;
+      this.updateStepForm();
+      return false;
+    }
+
     return true;
   }
 
   buildSaleData() {
+    const vendedorId =
+      parseInt(document.getElementById('vendedor-select-nts')?.value) ||
+      AppState.currentSale.vendedor_id ||
+      null;
     return {
-      numero_venta: this.generateSaleNumber(),
+      id: AppState.editingSaleId || undefined,
+      numero_venta:
+        AppState.currentSale.numero_venta || this.generateSaleNumber(),
       cliente: AppState.currentSale.client,
       viaje: AppState.currentSale.trip,
       servicios: AppState.currentSale.services,
       totales: AppState.currentSale.totals,
+      fecha_venta: AppState.currentSale.fechaVenta,
       fecha_creacion: new Date().toISOString(),
       estado: 'pendiente',
-      estado_pago: 'no_pagado'
+      estado_pago: 'no_pagado',
+      vendedor_id: vendedorId
     };
   }
 
@@ -1220,6 +1448,8 @@ class NTSApp {
       .insert({
         numero_venta: saleData.numero_venta,
         cliente_id: saleData.cliente.id || null,
+        vendedor_id: saleData.vendedor_id,
+        fecha_venta: saleData.fecha_venta,
         fecha_viaje_inicio: saleData.viaje.fechaInicio || null,
         fecha_viaje_fin: saleData.viaje.fechaFin || null,
         observaciones: saleData.viaje.observaciones || null,
@@ -1231,7 +1461,7 @@ class NTSApp {
       .single();
 
     if (ventaError) {
-      console.error('Error creando venta:', ventaError);
+      console.error('Error creando venta:', ventaError.message, ventaError.details);
       throw ventaError;
     }
 
@@ -1241,18 +1471,24 @@ class NTSApp {
           .from('venta_vuelos')
           .insert({
             venta_id: venta.id,
-            origen: servicio.origen,
-            destino: servicio.destino,
-            fecha: servicio.fecha,
+            descripcion: servicio.descripcion,
+            tipo_itinerario: servicio.tipo_itinerario,
             pasajeros: servicio.pasajeros,
-            aerolinea: servicio.aerolinea,
-            precio: servicio.precio
+            precio_costo: servicio.costo,
+            precio_venta: servicio.precio,
+            margen_ganancia: servicio.precio - servicio.costo,
+            monto_pagado: 0,
+            saldo_pendiente_servicio: servicio.costo,
+            estado_pago_servicio: 'no_pagado',
+            tiempo_total_vuelo: servicio.tiempo_total_vuelo || null,
+            cantidad_escalas: servicio.cantidad_escalas || 0,
+            tiene_escalas: servicio.tieneEscalas
           })
           .select()
           .single();
 
         if (vueloError) {
-          console.error('Error creando vuelo:', vueloError);
+          console.error('Error creando vuelo:', vueloError.message, vueloError.details);
           throw vueloError;
         }
 
@@ -1263,13 +1499,18 @@ class NTSApp {
             aeropuerto_origen: seg.aeropuerto_origen,
             aeropuerto_destino: seg.aeropuerto_destino,
             fecha_hora_salida_local: seg.fecha_hora_salida_local,
-            fecha_hora_llegada_local: seg.fecha_hora_llegada_local
+            fecha_hora_llegada_local: seg.fecha_hora_llegada_local,
+            aerolinea: seg.aerolinea || null,
+            numero_vuelo: seg.numero_vuelo || null,
+            tiene_escala: seg.tiene_escala,
+            aeropuerto_escala: seg.escalas[0]?.aeropuerto || null,
+            duracion_escala: seg.escalas[0]?.duracion || null
           }));
           const { error: segError } = await AppState.supabase
-            .from('venta_vuelo_segmentos')
+            .from('vuelo_segmentos')
             .insert(segmentos);
           if (segError) {
-            console.error('Error creando segmentos:', segError);
+            console.error('Error creando segmentos:', segError.message, segError.details);
             throw segError;
           }
         }
@@ -1277,10 +1518,138 @@ class NTSApp {
     }
   }
 
+  async updateSaleInDB(saleData) {
+    if (!AppState.supabase || !AppState.editingSaleId) return;
+    const id = AppState.editingSaleId;
+
+    const { error: ventaError } = await AppState.supabase
+      .from('ventas')
+      .update({
+        cliente_id: saleData.cliente.id || null,
+        vendedor_id: saleData.vendedor_id,
+        fecha_venta: saleData.fecha_venta,
+        fecha_viaje_inicio: saleData.viaje.fechaInicio || null,
+        fecha_viaje_fin: saleData.viaje.fechaFin || null,
+        observaciones: saleData.viaje.observaciones || null,
+        total_final: saleData.totales.total,
+        estado: saleData.estado,
+        estado_pago: saleData.estado_pago
+      })
+      .eq('id', id);
+    if (ventaError) throw ventaError;
+
+    // Remove existing services
+    const { data: vuelosExistentes } = await AppState.supabase
+      .from('venta_vuelos')
+      .select('id')
+      .eq('venta_id', id);
+    if (vuelosExistentes) {
+      for (const v of vuelosExistentes) {
+        await AppState.supabase
+          .from('vuelo_segmentos')
+          .delete()
+          .eq('venta_vuelo_id', v.id);
+      }
+    }
+    await AppState.supabase.from('venta_vuelos').delete().eq('venta_id', id);
+    await AppState.supabase.from('venta_hoteles').delete().eq('venta_id', id);
+    await AppState.supabase.from('venta_traslados').delete().eq('venta_id', id);
+    await AppState.supabase.from('venta_excursiones').delete().eq('venta_id', id);
+
+    for (const servicio of saleData.servicios) {
+      if (servicio.type === 'vuelo') {
+        const { data: vuelo, error: vueloError } = await AppState.supabase
+          .from('venta_vuelos')
+          .insert({
+            venta_id: id,
+            descripcion: servicio.descripcion,
+            tipo_itinerario: servicio.tipo_itinerario,
+            pasajeros: servicio.pasajeros,
+            precio_costo: servicio.costo,
+            precio_venta: servicio.precio,
+            margen_ganancia: servicio.precio - servicio.costo,
+            monto_pagado: 0,
+            saldo_pendiente_servicio: servicio.costo,
+            estado_pago_servicio: 'no_pagado',
+            tiempo_total_vuelo: servicio.tiempo_total_vuelo || null,
+            cantidad_escalas: servicio.cantidad_escalas || 0,
+            tiene_escalas: servicio.tieneEscalas
+          })
+          .select()
+          .single();
+        if (vueloError) throw vueloError;
+        if (servicio.segmentos && servicio.segmentos.length) {
+          const segmentos = servicio.segmentos.map(seg => ({
+            venta_vuelo_id: vuelo.id,
+            numero_segmento: seg.numero_segmento,
+            aeropuerto_origen: seg.aeropuerto_origen,
+            aeropuerto_destino: seg.aeropuerto_destino,
+            fecha_hora_salida_local: seg.fecha_hora_salida_local,
+            fecha_hora_llegada_local: seg.fecha_hora_llegada_local,
+            aerolinea: seg.aerolinea || null,
+            numero_vuelo: seg.numero_vuelo || null,
+            tiene_escala: seg.tiene_escala,
+            aeropuerto_escala: seg.escalas[0]?.aeropuerto || null,
+            duracion_escala: seg.escalas[0]?.duracion || null
+          }));
+          const { error: segError } = await AppState.supabase
+            .from('vuelo_segmentos')
+            .insert(segmentos);
+          if (segError) throw segError;
+        }
+      } else if (servicio.type === 'hotel') {
+        await AppState.supabase.from('venta_hoteles').insert({
+          venta_id: id,
+          hotel_nombre: servicio.nombre,
+          hotel_ciudad: servicio.ciudad,
+          fecha_checkin: servicio.checkin,
+          fecha_checkout: servicio.checkout,
+          huespedes: servicio.huespedes || 1,
+          precio_costo: servicio.costo,
+          precio_venta: servicio.precio,
+          margen_ganancia: servicio.precio - servicio.costo
+        });
+      } else if (servicio.type === 'traslado') {
+        await AppState.supabase.from('venta_traslados').insert({
+          venta_id: id,
+          origen: servicio.origen,
+          destino: servicio.destino,
+          fecha_traslado: servicio.fecha,
+          hora_traslado: servicio.hora,
+          pasajeros: servicio.pasajeros || 1,
+          precio_costo: servicio.costo,
+          precio_venta: servicio.precio,
+          margen_ganancia: servicio.precio - servicio.costo
+        });
+      } else if (servicio.type === 'excursion') {
+        await AppState.supabase.from('venta_excursiones').insert({
+          venta_id: id,
+          nombre_excursion: servicio.nombre,
+          destino_excursion: servicio.destino,
+          fecha_excursion: servicio.fecha,
+          duracion_horas: servicio.duracion,
+          participantes: servicio.participantes || 1,
+          precio_costo: servicio.costo,
+          precio_venta: servicio.precio,
+          margen_ganancia: servicio.precio - servicio.costo
+        });
+      }
+    }
+  }
+
+  updateSaleLocally(saleData) {
+    let sales = JSON.parse(localStorage.getItem('nts_ventas') || '[]');
+    sales = sales.map(s =>
+      s.id === AppState.editingSaleId ? { ...saleData, id: AppState.editingSaleId } : s
+    );
+    localStorage.setItem('nts_ventas', JSON.stringify(sales));
+    console.log('Venta actualizada localmente:', saleData);
+  }
+
   createSaleLocally(saleData) {
-    const sales = JSON.parse(localStorage.getItem('nts_sales') || '[]');
+    const sales = JSON.parse(localStorage.getItem('nts_ventas') || '[]');
     sales.push({ ...saleData, id: Date.now() });
-    localStorage.setItem('nts_sales', JSON.stringify(sales));
+    localStorage.setItem('nts_ventas', JSON.stringify(sales));
     console.log('Venta guardada localmente:', saleData);
   }
 
@@ -1289,9 +1658,14 @@ class NTSApp {
       client: {},
       trip: {},
       services: [],
-      totals: { subtotal: 0, descuentos: 0, total: 0 }
+      totals: { subtotal: 0, descuentos: 0, total: 0 },
+      fechaVenta: null,
+      numero_venta: null,
+      vendedor_id: null
     };
-    
+    AppState.editingSaleId = null;
+    AppState.editingServiceId = null;
+
     AppState.currentStep = 1;
     this.updateStepForm();
     this.updateServicesList();
@@ -1301,6 +1675,18 @@ class NTSApp {
     document.querySelectorAll('.form-control').forEach(input => {
       input.value = '';
     });
+
+    const docTipo = document.getElementById('cliente-doc-tipo');
+    if (docTipo) {
+      docTipo.value = 'dni';
+      this.toggleDocumentoFields();
+    }
+
+    const createBtn = document.getElementById('create-sale');
+    if (createBtn) {
+      createBtn.innerHTML = '<i data-lucide="check"></i> Crear Venta';
+      if (window.lucide) window.lucide.createIcons();
+    }
   }
 
   saveDraft() {
@@ -1309,9 +1695,341 @@ class NTSApp {
       isDraft: true,
       lastModified: new Date().toISOString()
     };
-    
+
     localStorage.setItem('nts_draft', JSON.stringify(draftData));
     this.showNotification('Borrador guardado', 'success');
+  }
+
+  async loadVentasList() {
+    const searchInput = document.getElementById('ventas-search');
+    const filterSelect = document.getElementById('ventas-filter');
+    const clientInput = document.getElementById('ventas-cliente');
+    const table = document.getElementById('ventas-table');
+
+    if (!this.ventasListenersSetup) {
+      const rerender = () => this.renderVentasTable(this.filterVentas());
+      searchInput?.addEventListener('input', rerender);
+      filterSelect?.addEventListener('change', rerender);
+      clientInput?.addEventListener('input', rerender);
+      table?.addEventListener('click', (e) => {
+        const editBtn = e.target.closest('[data-action="edit"]');
+        const deleteBtn = e.target.closest('[data-action="delete"]');
+        const id = editBtn?.dataset.id || deleteBtn?.dataset.id;
+        if (editBtn) this.editVenta(id);
+        if (deleteBtn) this.deleteVenta(id);
+      });
+      this.ventasListenersSetup = true;
+    }
+
+    try {
+      if (AppState.isConnected && AppState.supabase) {
+        const { data, error } = await AppState.supabase
+          .from('ventas')
+          .select('id, numero_venta, fecha_venta, total_final, estado, clientes (nombre)')
+          .order('fecha_venta', { ascending: false });
+        if (error) throw error;
+        AppState.ventas = (data || []).map(v => ({
+          id: v.id,
+          numero_venta: v.numero_venta,
+          fecha_venta: v.fecha_venta,
+          total_final: v.total_final,
+          estado: v.estado,
+          cliente_nombre: v.clientes?.nombre || ''
+        }));
+      } else {
+        const ventas = JSON.parse(localStorage.getItem('nts_ventas') || '[]');
+        AppState.ventas = ventas.map(v => ({
+          id: v.id,
+          numero_venta: v.numero_venta,
+          fecha_venta: v.fecha_venta || v.created_at,
+          total_final: v.total_final || v.total,
+          estado: v.estado || 'pendiente',
+          cliente_nombre: v.cliente?.nombre || ''
+        }));
+      }
+    } catch (err) {
+      console.error('Error cargando ventas:', err);
+      this.showNotification('Error cargando ventas', 'error');
+      AppState.ventas = [];
+    }
+
+    const clientList = document.getElementById('ventas-clientes');
+    if (clientList) {
+      const uniqueClients = [...new Set(AppState.ventas.map(v => v.cliente_nombre).filter(Boolean))];
+      clientList.innerHTML = uniqueClients.map(n => `<option value="${n}"></option>`).join('');
+    }
+
+    this.renderVentasTable(this.filterVentas());
+    this.updateVentasStats();
+  }
+
+  filterVentas() {
+    const term = document.getElementById('ventas-search')?.value.toLowerCase() || '';
+    const estado = document.getElementById('ventas-filter')?.value || '';
+    const cliente = document.getElementById('ventas-cliente')?.value.toLowerCase() || '';
+    return AppState.ventas.filter(v => {
+      const matchesTerm = v.numero_venta?.toLowerCase().includes(term) ||
+        v.cliente_nombre?.toLowerCase().includes(term);
+      const matchesEstado = !estado || v.estado === estado;
+      const matchesCliente = !cliente || v.cliente_nombre?.toLowerCase().includes(cliente);
+      return matchesTerm && matchesEstado && matchesCliente;
+    });
+  }
+
+  renderVentasTable(ventas) {
+    const tbody = document.querySelector('#ventas-table tbody');
+    if (!tbody) return;
+    if (!ventas.length) {
+      tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;">Sin ventas registradas</td></tr>';
+      return;
+    }
+
+    tbody.innerHTML = ventas.map(v => `
+      <tr>
+        <td>${v.numero_venta || ''}</td>
+        <td>${v.cliente_nombre || ''}</td>
+        <td>${this.formatDate(v.fecha_venta)}</td>
+        <td>${this.formatCurrency(v.total_final || 0)}</td>
+        <td>${v.estado || ''}</td>
+        <td class="table-row-actions">
+          <button class="btn-icon" data-action="edit" data-id="${v.id}" title="Editar"><i data-lucide="edit"></i></button>
+          <button class="btn-icon btn-danger" data-action="delete" data-id="${v.id}" title="Eliminar"><i data-lucide="trash-2"></i></button>
+        </td>
+      </tr>
+    `).join('');
+
+    if (window.lucide) window.lucide.createIcons();
+  }
+
+  async editVenta(id) {
+    try {
+      let data;
+      if (AppState.isConnected && AppState.supabase) {
+        const { data: venta, error } = await AppState.supabase
+          .from('ventas')
+          .select(`
+            *,
+            clientes(*),
+            venta_vuelos:venta_vuelos(
+              *,
+              vuelo_segmentos:vuelo_segmentos(*)
+            ),
+            venta_hoteles:venta_hoteles(*),
+            venta_traslados:venta_traslados(*),
+            venta_excursiones:venta_excursiones(*)
+          `)
+          .eq('id', id)
+          .single();
+        if (error) throw error;
+        data = venta;
+      } else {
+        const ventas = JSON.parse(localStorage.getItem('nts_ventas') || '[]');
+        data = ventas.find(v => v.id === Number(id));
+        if (!data) throw new Error('Venta no encontrada');
+      }
+
+      AppState.currentSale = {
+        client: data.clientes ? {
+          id: data.cliente_id,
+          nombre: data.clientes.nombre,
+          email: data.clientes.email,
+          telefono: data.clientes.telefono,
+          DNI: data.clientes.dni || data.clientes.DNI || '',
+          Pasaporte: data.clientes.Pasaporte || '',
+          dni_expiracion: data.clientes.dni_expiracion || '',
+          pasaporte_expiracion: data.clientes.pasaporte_expiracion || '',
+          vendedor_id: data.vendedor_id
+        } : (data.cliente || {}),
+        trip: {
+          fechaInicio: data.fecha_viaje_inicio || '',
+          fechaFin: data.fecha_viaje_fin || '',
+          observaciones: data.observaciones || ''
+        },
+        services: [],
+        totals: { subtotal: data.total_final || 0, descuentos: 0, total: data.total_final || 0 },
+        fechaVenta: data.fecha_venta || null,
+        numero_venta: data.numero_venta,
+        vendedor_id: data.vendedor_id
+      };
+
+      if (data.venta_vuelos) {
+        const vuelos = Array.isArray(data.venta_vuelos) ? data.venta_vuelos : [data.venta_vuelos];
+        vuelos.forEach(v => {
+          const segmentos = (v.vuelo_segmentos || [])
+            .sort((a, b) => (a.numero_segmento || 0) - (b.numero_segmento || 0))
+            .map(seg => ({
+              numero_segmento: seg.numero_segmento,
+              aeropuerto_origen: seg.aeropuerto_origen,
+              aeropuerto_destino: seg.aeropuerto_destino,
+              aerolinea: seg.aerolinea,
+              numero_vuelo: seg.numero_vuelo,
+              fecha_hora_salida_local: seg.fecha_hora_salida_local,
+              fecha_hora_llegada_local: seg.fecha_hora_llegada_local,
+              tiempo_total_tramo: seg.tiempo_vuelo || '',
+              escalas: seg.tiene_escala && seg.aeropuerto_escala ? [{ aeropuerto: seg.aeropuerto_escala, duracion: seg.duracion_escala }] : [],
+              tiene_escala: seg.tiene_escala
+            }));
+
+          const origen = v.origen || segmentos[0]?.aeropuerto_origen || '';
+          const destino = v.destino || segmentos[segmentos.length - 1]?.aeropuerto_destino || '';
+
+          AppState.currentSale.services.push({
+            id: Date.now() + Math.random(),
+            type: 'vuelo',
+            costo: v.precio_costo || 0,
+            precio: v.precio_venta || 0,
+            pasajeros: v.pasajeros || 1,
+            tipo_itinerario: v.tipo_itinerario || 'ida_vuelta',
+            origen,
+            destino,
+            descripcion: v.descripcion || '',
+            tieneEscalas: v.tiene_escalas || segmentos.some(s => s.tiene_escala),
+            cantidad_escalas: v.cantidad_escalas || segmentos.filter(s => s.tiene_escala).length,
+            tiempo_total_vuelo: v.tiempo_total_vuelo || null,
+            segmentos
+          });
+        });
+      }
+      if (data.venta_hoteles) {
+        const hoteles = Array.isArray(data.venta_hoteles) ? data.venta_hoteles : [data.venta_hoteles];
+        hoteles.forEach(h => {
+          AppState.currentSale.services.push({
+            id: Date.now() + Math.random(),
+            type: 'hotel',
+            costo: h.precio_costo || 0,
+            precio: h.precio_venta || 0,
+            nombre: h.hotel_nombre,
+            ciudad: h.hotel_ciudad,
+            checkin: h.fecha_checkin,
+            checkout: h.fecha_checkout,
+            huespedes: h.huespedes || 1
+          });
+        });
+      }
+      if (data.venta_traslados) {
+        const traslados = Array.isArray(data.venta_traslados) ? data.venta_traslados : [data.venta_traslados];
+        traslados.forEach(t => {
+          AppState.currentSale.services.push({
+            id: Date.now() + Math.random(),
+            type: 'traslado',
+            costo: t.precio_costo || 0,
+            precio: t.precio_venta || 0,
+            origen: t.origen,
+            destino: t.destino,
+            fecha: t.fecha_traslado,
+            hora: t.hora_traslado,
+            pasajeros: t.pasajeros || 1
+          });
+        });
+      }
+      if (data.venta_excursiones) {
+        const excursiones = Array.isArray(data.venta_excursiones) ? data.venta_excursiones : [data.venta_excursiones];
+        excursiones.forEach(ex => {
+          AppState.currentSale.services.push({
+            id: Date.now() + Math.random(),
+            type: 'excursion',
+            costo: ex.precio_costo || 0,
+            precio: ex.precio_venta || 0,
+            nombre: ex.nombre_excursion,
+            destino: ex.destino_excursion,
+            fecha: ex.fecha_excursion,
+            duracion: ex.duracion_horas,
+            participantes: ex.participantes || 1
+          });
+        });
+      }
+
+      AppState.editingSaleId = Number(id);
+      this.showTab('nueva-venta');
+      setTimeout(() => {
+        this.fillSaleForm();
+        const createBtn = document.getElementById('create-sale');
+        if (createBtn) {
+          createBtn.innerHTML = '<i data-lucide="check"></i> Guardar Venta';
+          if (window.lucide) window.lucide.createIcons();
+        }
+      });
+      this.showNotification('Editando venta', 'info');
+    } catch (err) {
+      console.error('Error cargando venta:', err);
+      this.showNotification('No se pudo cargar la venta', 'error');
+    }
+  }
+
+  fillSaleForm() {
+    const c = AppState.currentSale.client || {};
+    document.getElementById('cliente-nombre').value = c.nombre || '';
+    document.getElementById('cliente-email').value = c.email || '';
+    document.getElementById('cliente-telefono').value = c.telefono || '';
+    const docTipo = document.getElementById('cliente-doc-tipo');
+    if (docTipo) {
+      const tipo = c.Pasaporte ? 'pasaporte' : 'dni';
+      docTipo.value = tipo;
+      this.toggleDocumentoFields(tipo);
+    }
+    document.getElementById('cliente-dni').value = c.DNI || '';
+    document.getElementById('cliente-dni-expiracion').value = c.dni_expiracion || '';
+    document.getElementById('cliente-pasaporte').value = c.Pasaporte || '';
+    document.getElementById('cliente-pasaporte-expiracion').value = c.pasaporte_expiracion || '';
+    document.getElementById('vendedor-select-nts').value = AppState.currentSale.vendedor_id || c.vendedor_id || '';
+
+    document.getElementById('fecha-venta').value = AppState.currentSale.fechaVenta || '';
+    document.getElementById('fecha-viaje-inicio').value = AppState.currentSale.trip.fechaInicio || '';
+    document.getElementById('fecha-viaje-fin').value = AppState.currentSale.trip.fechaFin || '';
+    document.getElementById('observaciones-venta').value = AppState.currentSale.trip.observaciones || '';
+
+    this.updateServicesList();
+    this.updateTotals();
+  }
+
+  async deleteVenta(id) {
+    if (!confirm('¿Eliminar esta venta?')) return;
+    try {
+      if (AppState.isConnected && AppState.supabase) {
+        const { error } = await AppState.supabase.from('ventas').delete().eq('id', id);
+        if (error) throw error;
+      } else {
+        let ventas = JSON.parse(localStorage.getItem('nts_ventas') || '[]');
+        ventas = ventas.filter(v => v.id !== Number(id));
+        localStorage.setItem('nts_ventas', JSON.stringify(ventas));
+      }
+      AppState.ventas = AppState.ventas.filter(v => v.id !== Number(id));
+      this.renderVentasTable(this.filterVentas());
+      this.updateVentasStats();
+      this.showNotification('Venta eliminada', 'success');
+    } catch (err) {
+      console.error('Error eliminando venta:', err);
+      this.showNotification('No se pudo eliminar la venta', 'error');
+    }
+  }
+
+  updateVentasStats() {
+    const now = new Date();
+    const ventasDelMes = AppState.ventas
+      .filter(v => {
+        const fecha = new Date(v.fecha_venta);
+        return fecha.getMonth() === now.getMonth() && fecha.getFullYear() === now.getFullYear();
+      })
+      .reduce((sum, v) => sum + (v.total_final || 0), 0);
+    const totalVentas = AppState.ventas.length;
+    const pendientes = AppState.ventas.filter(v => v.estado !== 'finalizada' && v.estado !== 'cancelada').length;
+    const totalClientes = parseInt(document.getElementById('total-clientes')?.textContent) || 0;
+    this.updateDashboardStats({ ventasDelMes, totalVentas, pendientes, totalClientes });
+
+    const clientList = document.getElementById('ventas-clientes');
+    if (clientList) {
+      const uniqueClients = [...new Set(AppState.ventas.map(v => v.cliente_nombre).filter(Boolean))];
+      clientList.innerHTML = uniqueClients.map(n => `<option value="${n}"></option>`).join('');
+    }
+  }
+
+  formatDate(dateStr) {
+    if (!dateStr) return '';
+    try {
+      return new Date(dateStr).toLocaleDateString('es-AR');
+    } catch {
+      return dateStr;
+    }
   }
 
   // ===== OTRAS FUNCIONES =====
@@ -1460,14 +2178,211 @@ class NTSApp {
   }
 }
 
+function addSegmentRow() {
+  const container = document.getElementById('segments-container');
+  if (!container) return;
+  const index = container.children.length + 1;
+
+  const row = document.createElement('div');
+  row.className = 'segment-row';
+
+  row.innerHTML = `
+    <div class="form-group">
+      <label>Origen Tramo ${index}</label>
+      <input type="text" class="form-control segment-origen" placeholder="Origen">
+    </div>
+    <div class="form-group">
+      <label>Destino Tramo ${index}</label>
+      <input type="text" class="form-control segment-destino" placeholder="Destino">
+    </div>
+    <div class="form-group">
+      <label>Aerolínea</label>
+      <input type="text" class="form-control segment-aerolinea" placeholder="Aerolínea">
+    </div>
+    <div class="form-group">
+      <label>Número de vuelo</label>
+      <input type="text" class="form-control segment-numero" placeholder="AB123">
+    </div>
+    <div class="form-group">
+      <label>Salida</label>
+      <input type="datetime-local" class="form-control segment-salida">
+    </div>
+    <div class="form-group">
+      <label>Llegada</label>
+      <input type="datetime-local" class="form-control segment-llegada">
+    </div>
+    <div class="form-group">
+      <label>Tiempo total de vuelo</label>
+      <input type="text" class="form-control segment-tiempo-total" placeholder="00:00" readonly>
+    </div>
+    <div class="form-group">
+      <label class="checkbox-container" style="margin-top: 1.5rem;">
+        <input type="checkbox" class="segment-has-escala">
+        <span class="checkmark"></span>
+        ¿El tramo tiene escalas?
+      </label>
+    </div>
+    <div class="form-group" style="display: flex; align-items: end;">
+      ${index > 1 ? `<button type="button" class="btn btn-danger remove-segment" onclick="removeSegmentRow(this)" title="Eliminar tramo"><i data-lucide="trash-2"></i></button>` : ''}
+    </div>
+    <div class="escalas-section" style="display: none;">
+      <div class="escalas-container"></div>
+      <button type="button" class="btn btn-secondary add-escala-btn" style="margin-top:0.5rem;">
+        <i data-lucide="plus"></i>
+        Agregar escala
+      </button>
+    </div>
+  `;
+
+  container.appendChild(row);
+
+  const updateTotal = () => updateSegmentTiempoTotal(row);
+  row.querySelector('.segment-salida').addEventListener('change', updateTotal);
+  row.querySelector('.segment-llegada').addEventListener('change', updateTotal);
+
+  const escalaToggle = row.querySelector('.segment-has-escala');
+  const escalaSection = row.querySelector('.escalas-section');
+  const addEscalaBtn = row.querySelector('.add-escala-btn');
+
+  if (escalaToggle && escalaSection) {
+    escalaToggle.addEventListener('change', () => {
+      escalaSection.style.display = escalaToggle.checked ? 'block' : 'none';
+      if (escalaToggle.checked && !escalaSection.querySelector('.escala-row')) {
+        addEscalaRowToSegment(row);
+      }
+      if (!escalaToggle.checked) {
+        escalaSection.querySelector('.escalas-container').innerHTML = '';
+        updateTotal();
+      }
+    });
+  }
+
+  addEscalaBtn.addEventListener('click', () => {
+    addEscalaRowToSegment(row);
+  });
+
+  if (window.lucide) {
+    window.lucide.createIcons();
+  }
+}
+
+function addEscalaRowToSegment(segmentRow) {
+  const container = segmentRow.querySelector('.escalas-container');
+  const index = container.children.length + 1;
+  const escalaRow = document.createElement('div');
+  escalaRow.className = 'escala-row';
+  escalaRow.innerHTML = `
+    <div class="form-group">
+      <label>Escala ${index}</label>
+      <input type="text" class="form-control segment-aeropuerto-escala" placeholder="Aeropuerto de escala">
+    </div>
+    <div class="form-group">
+      <label>Duración</label>
+      <input type="text" class="form-control segment-duracion-escala" placeholder="01:30">
+    </div>
+    <div class="form-group" style="display:flex; align-items:end;">
+      <button type="button" class="btn btn-danger remove-escala" title="Eliminar escala"><i data-lucide="trash-2"></i></button>
+    </div>
+  `;
+  container.appendChild(escalaRow);
+
+  escalaRow.querySelector('.segment-duracion-escala').addEventListener('input', () => updateSegmentTiempoTotal(segmentRow));
+  escalaRow.querySelector('.remove-escala').addEventListener('click', () => removeEscalaRow(escalaRow, segmentRow));
+
+  renumberEscalas(segmentRow);
+
+  if (window.lucide) {
+    window.lucide.createIcons();
+  }
+}
+
+function removeEscalaRow(escalaRow, segmentRow) {
+  escalaRow.remove();
+  renumberEscalas(segmentRow);
+  updateSegmentTiempoTotal(segmentRow);
+  app?.showNotification('🗑️ Escala eliminada', 'info');
+}
+
+function renumberEscalas(segmentRow) {
+  const container = segmentRow.querySelector('.escalas-container');
+  Array.from(container.children).forEach((row, idx) => {
+    const label = row.querySelector('label');
+    if (label) label.textContent = `Escala ${idx + 1}`;
+  });
+}
+
+function parseDurationToMinutes(val) {
+  const parts = val.split(':').map(Number);
+  if (parts.length !== 2) return 0;
+  const [h, m] = parts;
+  return (isNaN(h) || isNaN(m)) ? 0 : h * 60 + m;
+}
+
+function updateSegmentTiempoTotal(row) {
+  const salida = row.querySelector('.segment-salida')?.value;
+  const llegada = row.querySelector('.segment-llegada')?.value;
+  const escalaDuraciones = Array.from(row.querySelectorAll('.segment-duracion-escala'))
+    .map(i => parseDurationToMinutes(i.value))
+    .reduce((acc, val) => acc + val, 0);
+
+  if (salida && llegada) {
+    const start = new Date(salida);
+    const end = new Date(llegada);
+    let diff = end - start;
+    if (!isNaN(diff) && diff >= 0) {
+      const totalMins = Math.floor(diff / 60000) + escalaDuraciones;
+      const hours = String(Math.floor(totalMins / 60)).padStart(2, '0');
+      const minutes = String(totalMins % 60).padStart(2, '0');
+      row.querySelector('.segment-tiempo-total').value = `${hours}:${minutes}`;
+      return;
+    }
+  }
+  row.querySelector('.segment-tiempo-total').value = '';
+}
+
+function removeSegmentRow(button) {
+  const row = button.closest('.segment-row');
+  row.remove();
+  renumberSegments();
+  app?.showNotification('🗑️ Tramo eliminado', 'info');
+}
+
+function renumberSegments() {
+  const container = document.getElementById('segments-container');
+  Array.from(container.children).forEach((row, index) => {
+    const labels = row.querySelectorAll('label');
+    labels[0].textContent = `Origen Tramo ${index + 1}`;
+    labels[1].textContent = `Destino Tramo ${index + 1}`;
+    const removeBtn = row.querySelector('.remove-segment');
+    if (removeBtn) {
+      if (index === 0) {
+        removeBtn.style.display = 'none';
+      } else {
+        removeBtn.style.display = 'inline-flex';
+      }
+    }
+  });
+}
+
+window.addSegmentRow = addSegmentRow;
+window.removeSegmentRow = removeSegmentRow;
+
+document.addEventListener('click', function(e) {
+  if (e.target.matches('#add-segment-btn')) {
+    e.preventDefault();
+    addSegmentRow();
+  }
+});
+
 // ===== INICIALIZACIÓN =====
 let app;
 
 document.addEventListener('DOMContentLoaded', () => {
   app = new NTSApp();
+  window.app = app;
 });
 
 // ===== EXPORT GLOBAL =====
-window.app = app;
+// "app" se define en DOMContentLoaded y se expone globalmente arriba
 
 console.log('✅ NTS Sistema v2.0 cargado correctamente');

--- a/js/modules/ventas.js
+++ b/js/modules/ventas.js
@@ -116,102 +116,216 @@ function loadMockData() {
 // ===== CONFIGURAR INTERFAZ =====
 function setupVentasUI() {
     console.log('🎨 Configurando interfaz...');
-    
-    // Crear select de vendedores
+
+    // Poblar select de vendedores
     createVendedorSelect();
-    
+
     // Configurar autocompletado de clientes
     setupClienteAutocomplete();
-    
+
+    // Configurar toggle de documentos
+    setupDocumentoToggle();
+
     // Crear selects de proveedores
     createProveedorSelects();
-    
-    // Actualizar descripción de vuelos automáticamente
-    setupVueloDescriptionUpdate();
-    
-    // Configurar Flatpickr
-    setupFlatpickrFields();
+
+    // Configuración adicional puede agregarse aquí
 }
 
 function createVendedorSelect() {
-    // Buscar si ya existe
-    if (document.getElementById('vendedor-select-nts')) return;
-    
-    const clienteSection = document.querySelector('#nueva-venta .form-section');
-    if (!clienteSection) return;
-    
-    const vendedorRow = document.createElement('div');
-    vendedorRow.className = 'form-row';
-    vendedorRow.innerHTML = `
-        <div>
-            <label for="vendedor-select-nts"><strong>🧑‍💼 Vendedor Responsable *</strong></label>
-            <select id="vendedor-select-nts" required>
-                <option value="">Seleccionar vendedor...</option>
-            </select>
-            <small>Seleccione el vendedor responsable de esta venta</small>
-        </div>
-    `;
-    
-    clienteSection.appendChild(vendedorRow);
-    
     const select = document.getElementById('vendedor-select-nts');
+    if (!select) return;
+
+    select.innerHTML = '<option value="">Seleccionar vendedor...</option>';
     VentasModule.vendedores.forEach(vendedor => {
         const option = document.createElement('option');
         option.value = vendedor.id;
         option.textContent = `${vendedor.nombre} (${vendedor.codigo_vendedor}) - ${vendedor.rol}`;
         select.appendChild(option);
     });
-    
-    console.log('✅ Select de vendedores creado');
+
+    console.log('✅ Select de vendedores cargado');
 }
+
+function toggleDocumentoFields(selected) {
+    const tipo = selected || document.getElementById('cliente-doc-tipo')?.value || 'dni';
+    const isDNI = tipo === 'dni';
+    document.getElementById('grupo-dni')?.classList.toggle('hidden', !isDNI);
+    document.getElementById('grupo-dni-exp')?.classList.toggle('hidden', !isDNI);
+    document.getElementById('grupo-pasaporte')?.classList.toggle('hidden', isDNI);
+    document.getElementById('grupo-pasaporte-exp')?.classList.toggle('hidden', isDNI);
+}
+
+function setupDocumentoToggle() {
+    const select = document.getElementById('cliente-doc-tipo');
+    if (!select) return;
+    select.addEventListener('change', (e) => toggleDocumentoFields(e.target.value));
+    toggleDocumentoFields(select.value);
+    window.toggleDocumentoFields = toggleDocumentoFields;
+}
+
 
 function setupClienteAutocomplete() {
     const clienteNombre = document.getElementById('cliente-nombre');
     if (!clienteNombre) return;
+
+    // Crear container de búsqueda
+    const searchContainer = document.createElement('div');
+    searchContainer.className = 'cliente-search-container';
+    searchContainer.style.cssText = `
+        position: relative;
+        width: 100%;
+    `;
+
+    // Envolver el input original
+    const originalParent = clienteNombre.parentNode;
+    originalParent.insertBefore(searchContainer, clienteNombre);
+    searchContainer.appendChild(clienteNombre);
+
+    // Crear dropdown de resultados
+    const dropdown = document.createElement('div');
+    dropdown.id = 'cliente-search-dropdown';
+    dropdown.style.cssText = `
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        background: white;
+        border: 1px solid var(--gray-300);
+        border-top: none;
+        border-radius: 0 0 0.5rem 0.5rem;
+        max-height: 200px;
+        overflow-y: auto;
+        z-index: 1000;
+        display: none;
+        box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+    `;
+    searchContainer.appendChild(dropdown);
+
+    // Agregar icono de búsqueda
+    clienteNombre.placeholder = "🔍 Buscar cliente existente o crear nuevo...";
     
-    // Crear datalist si no existe
-    let datalist = document.getElementById('clientes-datalist-nts');
-    if (!datalist) {
-        datalist = document.createElement('datalist');
-        datalist.id = 'clientes-datalist-nts';
-        document.body.appendChild(datalist);
-    }
+    let searchTimeout;
     
-    // Llenar datalist
-    datalist.innerHTML = '';
-    VentasModule.clientesExistentes.forEach(cliente => {
-        const option = document.createElement('option');
-        option.value = cliente.nombre;
-        option.setAttribute('data-email', cliente.email || '');
-        option.setAttribute('data-telefono', cliente.telefono || '');
-        option.setAttribute('data-id', cliente.id);
-        datalist.appendChild(option);
-    });
-    
-    clienteNombre.setAttribute('list', 'clientes-datalist-nts');
-    
-    // Event listener para autocompletar
+    // Event listener para búsqueda en tiempo real
     clienteNombre.addEventListener('input', function() {
-        const selectedOption = [...datalist.options].find(option => option.value === this.value);
+        clearTimeout(searchTimeout);
+        const searchTerm = this.value.trim().toLowerCase();
         
-        if (selectedOption) {
-            const emailField = document.getElementById('cliente-email');
-            const telefonoField = document.getElementById('cliente-telefono');
-            
-            if (emailField) emailField.value = selectedOption.getAttribute('data-email');
-            if (telefonoField) telefonoField.value = selectedOption.getAttribute('data-telefono');
-            
-            VentasModule.currentVenta.cliente.id = selectedOption.getAttribute('data-id');
-            VentasModule.currentVenta.cliente.esExistente = true;
-            
-            showNotification('✅ Cliente encontrado - datos autocompletados', 'success');
-        } else {
-            VentasModule.currentVenta.cliente.esExistente = false;
+        if (searchTerm.length < 2) {
+            hideDropdown();
+            return;
+        }
+        
+        searchTimeout = setTimeout(() => {
+            searchClientes(searchTerm);
+        }, 300); // Debounce de 300ms
+    });
+
+    // Ocultar dropdown al hacer clic fuera
+    document.addEventListener('click', function(e) {
+        if (!searchContainer.contains(e.target)) {
+            hideDropdown();
         }
     });
-    
-    console.log('✅ Autocompletado de clientes configurado');
+
+    function searchClientes(searchTerm) {
+        // Filtrar clientes que coincidan con el término de búsqueda
+        const clientesFiltrados = VentasModule.clientesExistentes.filter(cliente => {
+            return cliente.nombre.toLowerCase().includes(searchTerm) ||
+                   (cliente.email && cliente.email.toLowerCase().includes(searchTerm)) ||
+                   (cliente.telefono && cliente.telefono.includes(searchTerm)) ||
+                   (cliente.DNI && cliente.DNI.includes(searchTerm)) ||
+                   (cliente.Pasaporte && cliente.Pasaporte.includes(searchTerm));
+        });
+
+        showSearchResults(clientesFiltrados, searchTerm);
+    }
+
+    function showSearchResults(clientes, searchTerm) {
+        const dropdown = document.getElementById('cliente-search-dropdown');
+        
+        if (clientes.length === 0) {
+            dropdown.innerHTML = `
+                <div class="search-result-item no-results">
+                    <div class="no-results-content">
+                        <i data-lucide="user-plus"></i>
+                        <span>No se encontraron clientes</span>
+                        <small>Se creará un cliente nuevo: "${searchTerm}"</small>
+                    </div>
+                </div>
+            `;
+        } else {
+            dropdown.innerHTML = clientes.map(cliente => `
+                <div class="search-result-item" onclick="selectCliente(${cliente.id}, '${cliente.nombre}', '${cliente.email || ''}', '${cliente.telefono || ''}', '${cliente.DNI || ''}', '${cliente.Pasaporte || ''}', '${cliente.dni_expiracion || ''}', '${cliente.pasaporte_expiracion || ''}')">
+                    <div class="cliente-info">
+                        <div class="cliente-nombre">${highlightMatch(cliente.nombre, searchTerm)}</div>
+                        <div class="cliente-detalles">
+                            ${cliente.email ? `📧 ${cliente.email}` : ''} 
+                            ${cliente.telefono ? `📱 ${cliente.telefono}` : ''}
+                        </div>
+                    </div>
+                    <div class="cliente-status">
+                        <span class="status-badge existing">Existente</span>
+                    </div>
+                </div>
+            `).join('');
+        }
+        
+        dropdown.style.display = 'block';
+        
+        // Re-inicializar iconos
+        if (window.lucide) {
+            window.lucide.createIcons();
+        }
+    }
+
+    function hideDropdown() {
+        const dropdown = document.getElementById('cliente-search-dropdown');
+        dropdown.style.display = 'none';
+    }
+
+    function highlightMatch(text, searchTerm) {
+        const regex = new RegExp(`(${searchTerm})`, 'gi');
+        return text.replace(regex, '<mark>$1</mark>');
+    }
 }
+
+// NUEVA FUNCIÓN GLOBAL: Seleccionar cliente
+window.selectCliente = function(id, nombre, email, telefono, dni, pasaporte, dniExp, pasaporteExp) {
+    document.getElementById('cliente-nombre').value = nombre;
+    document.getElementById('cliente-email').value = email;
+    document.getElementById('cliente-telefono').value = telefono;
+
+    const tipoSelect = document.getElementById('cliente-doc-tipo');
+    if (dni) {
+        tipoSelect.value = 'dni';
+        toggleDocumentoFields('dni');
+        document.getElementById('cliente-dni').value = dni;
+        document.getElementById('cliente-dni-expiracion').value = dniExp || '';
+        document.getElementById('cliente-pasaporte').value = '';
+        document.getElementById('cliente-pasaporte-expiracion').value = '';
+    } else {
+        tipoSelect.value = 'pasaporte';
+        toggleDocumentoFields('pasaporte');
+        document.getElementById('cliente-pasaporte').value = pasaporte;
+        document.getElementById('cliente-pasaporte-expiracion').value = pasaporteExp || '';
+        document.getElementById('cliente-dni').value = '';
+        document.getElementById('cliente-dni-expiracion').value = '';
+    }
+
+    VentasModule.currentVenta.cliente = {
+        id: id,
+        nombre: nombre,
+        email: email,
+        telefono: telefono,
+        esExistente: true
+    };
+
+    document.getElementById('cliente-search-dropdown').style.display = 'none';
+    showNotification(`✅ Cliente seleccionado: ${nombre}`, 'success');
+    document.getElementById('cliente-email')?.focus();
+};
 
 function createProveedorSelects() {
     const serviceForms = ['vuelo', 'hotel', 'traslado', 'excursion'];
@@ -274,26 +388,6 @@ function createProveedorSelects() {
     console.log('✅ Selects de proveedores creados');
 }
 
-function setupVueloDescriptionUpdate() {
-    const origenInput = document.getElementById('vuelo-origen');
-    const destinoInput = document.getElementById('vuelo-destino');
-    const descripcionInput = document.getElementById('vuelo-descripcion');
-    
-    if (!origenInput || !destinoInput || !descripcionInput) return;
-    
-    function updateDescription() {
-        const origen = origenInput.value.trim();
-        const destino = destinoInput.value.trim();
-        
-        if (origen && destino) {
-            descripcionInput.value = `Vuelo ${origen} → ${destino}`;
-        }
-    }
-    
-    origenInput.addEventListener('input', updateDescription);
-    destinoInput.addEventListener('input', updateDescription);
-}
-
 // ===== CONFIGURAR FLATPICKR - VERSIÓN SIN DUPLICADOS =====
 function setupFlatpickrFields() {
     console.log('📅 Configurando Flatpickr...');
@@ -339,7 +433,7 @@ function setupFlatpickrFields() {
     createDateFieldsForType('ida_vuelta'); // Por defecto ida y vuelta
     
     // Configurar listener para cambio de tipo
-    const tipoSelect = document.getElementById('vuelo-tipo');
+    const tipoSelect = document.getElementById('vuelo-itinerario');
     if (tipoSelect) {
         tipoSelect.addEventListener('change', function() {
             console.log(`🔄 Cambiando tipo de vuelo a: ${this.value}`);
@@ -511,6 +605,16 @@ function setupVentasEvents() {
             calculateMargin(e.target);
         }
     });
+
+    // Event listener para botón de agregar tramo
+    document.addEventListener('click', function(e) {
+        if (e.target.matches('#add-segment-btn')) {
+            e.preventDefault();
+            if (typeof addSegmentRow === 'function') {
+                addSegmentRow();
+            }
+        }
+    });
 }
 
 function calculateMargin(element) {
@@ -578,32 +682,41 @@ function getServiceFormData(tipo) {
     
     switch(tipo) {
         case 'vuelo':
-            const origen = document.getElementById('vuelo-origen')?.value?.trim() || '';
-            const destino = document.getElementById('vuelo-destino')?.value?.trim() || '';
-            const descripcionManual = document.getElementById('vuelo-descripcion')?.value?.trim();
-            
-            // Generar descripción automática
-            let descripcion = descripcionManual;
-            if (!descripcion && origen && destino) {
-                descripcion = `Vuelo ${origen} → ${destino}`;
-            }
-            
+            const segmentRows = document.querySelectorAll('#segments-container .segment-row');
+            const segmentos = Array.from(segmentRows).map((row, index) => {
+                const escalas = Array.from(row.querySelectorAll('.escala-row')).map(er => ({
+                    aeropuerto: er.querySelector('.segment-aeropuerto-escala')?.value?.trim(),
+                    duracion: er.querySelector('.segment-duracion-escala')?.value?.trim()
+                }));
+                return {
+                    numero_segmento: index + 1,
+                    aeropuerto_origen: row.querySelector('.segment-origen')?.value?.trim(),
+                    aeropuerto_destino: row.querySelector('.segment-destino')?.value?.trim(),
+                    aerolinea: row.querySelector('.segment-aerolinea')?.value?.trim(),
+                    numero_vuelo: row.querySelector('.segment-numero')?.value?.trim(),
+                    fecha_hora_salida_local: row.querySelector('.segment-salida')?.value || null,
+                    fecha_hora_llegada_local: row.querySelector('.segment-llegada')?.value || null,
+                    tiempo_total_tramo: row.querySelector('.segment-tiempo-total')?.value?.trim() || '',
+                    escalas,
+                    tiene_escala: escalas.length > 0
+                };
+            });
+
+            const origen = segmentos[0]?.aeropuerto_origen || '';
+            const destino = segmentos[segmentos.length - 1]?.aeropuerto_destino || '';
+            const tieneEscalas = segmentos.some(s => s.tiene_escala);
+            const descripcion = origen && destino ? `Vuelo ${origen} → ${destino}` : 'Vuelo';
+            const tipo_itinerario = document.getElementById('vuelo-itinerario')?.value || 'ida_vuelta';
+
             return {
                 ...baseData,
-                descripcion: descripcion || `Vuelo ${origen} → ${destino}`,
-                origen: origen,
-                destino: destino,
-                tipo_itinerario: document.getElementById('vuelo-tipo')?.value || 'ida_vuelta',
-                aerolinea: document.getElementById('vuelo-aerolinea')?.value?.trim() || '',
-                clase_vuelo: document.getElementById('vuelo-clase')?.value || 'economica',
                 pasajeros: parseInt(document.getElementById('vuelo-pasajeros')?.value) || 1,
-                
-                // Fechas y horas de Flatpickr
-                fecha_hora_salida: document.getElementById('vuelo-fecha-salida-flat')?.value || null,
-                fecha_hora_llegada: document.getElementById('vuelo-fecha-llegada-flat')?.value || null,
-                fecha_hora_regreso: document.getElementById('vuelo-fecha-regreso-flat')?.value || null,
-                fecha_hora_llegada_regreso: document.getElementById('vuelo-fecha-llegada-regreso-flat')?.value || null,
-                itinerario_observaciones: document.getElementById('vuelo-itinerario-observaciones')?.value?.trim() || ''
+                tipo_itinerario,
+                origen,
+                destino,
+                descripcion,
+                tieneEscalas,
+                segmentos
             };
         case 'hotel':
             return {
@@ -648,12 +761,20 @@ function validateServiceData(serviceData, tipo) {
     // Validaciones específicas por tipo
     switch(tipo) {
         case 'vuelo':
-            if (!serviceData.origen || !serviceData.destino) {
-                showNotification('⚠️ Complete origen y destino del vuelo', 'warning');
+            if (!serviceData.segmentos || serviceData.segmentos.length === 0) {
+                showNotification('⚠️ Agregue al menos un tramo', 'warning');
                 return false;
             }
-            if (serviceData.origen.trim() === '' || serviceData.destino.trim() === '') {
-                showNotification('⚠️ Origen y destino no pueden estar vacíos', 'warning');
+
+            const invalid = serviceData.segmentos.some(s => !s.aeropuerto_origen || !s.aeropuerto_destino || !s.aerolinea || !s.numero_vuelo);
+            if (invalid) {
+                showNotification('⚠️ Complete origen, destino, aerolínea y número de vuelo en todos los tramos', 'warning');
+                return false;
+            }
+
+            const escalaInvalid = serviceData.segmentos.some(s => s.tiene_escala && (s.escalas.length === 0 || s.escalas.some(e => !e.aeropuerto || !e.duracion)));
+            if (escalaInvalid) {
+                showNotification('⚠️ Complete los datos de todas las escalas', 'warning');
                 return false;
             }
             break;
@@ -709,11 +830,21 @@ function clearServiceForm(tipo) {
     serviceForm.querySelectorAll('textarea').forEach(textarea => {
         textarea.value = '';
     });
-    
+
     // Remover display de margen
     const margenDisplay = serviceForm.querySelector('.margen-display-nts');
     if (margenDisplay) {
         margenDisplay.remove();
+    }
+
+    if (tipo === 'vuelo') {
+        const segmentsContainer = document.getElementById('segments-container');
+        if (segmentsContainer) {
+            segmentsContainer.innerHTML = '';
+            if (typeof addSegmentRow === 'function') {
+                addSegmentRow();
+            }
+        }
     }
 }
 
@@ -853,16 +984,38 @@ async function crearVentaCompleta() {
 function validateVentaForm() {
     const clienteNombre = document.getElementById('cliente-nombre')?.value?.trim();
     const vendedorId = document.getElementById('vendedor-select-nts')?.value;
-    
+    const docTipo = document.getElementById('cliente-doc-tipo')?.value;
+    const dni = document.getElementById('cliente-dni')?.value?.trim();
+    const pasaporte = document.getElementById('cliente-pasaporte')?.value?.trim();
+
     if (!clienteNombre) {
         showNotification('⚠️ Ingrese el nombre del cliente', 'warning');
         document.getElementById('cliente-nombre')?.focus();
         return false;
     }
-    
+
+    if (docTipo === 'dni' && !dni) {
+        showNotification('⚠️ Ingrese el DNI del cliente', 'warning');
+        document.getElementById('cliente-dni')?.focus();
+        return false;
+    }
+
+    if (docTipo === 'pasaporte' && !pasaporte) {
+        showNotification('⚠️ Ingrese el pasaporte del cliente', 'warning');
+        document.getElementById('cliente-pasaporte')?.focus();
+        return false;
+    }
+
     if (!vendedorId) {
         showNotification('⚠️ Seleccione un vendedor responsable', 'warning');
         document.getElementById('vendedor-select-nts')?.focus();
+        return false;
+    }
+
+    const fechaVenta = document.getElementById('fecha-venta')?.value;
+    if (!fechaVenta) {
+        showNotification('⚠️ Ingrese la fecha de venta', 'warning');
+        document.getElementById('fecha-venta')?.focus();
         return false;
     }
     
@@ -882,14 +1035,17 @@ function buildVentaData() {
             nombre: document.getElementById('cliente-nombre')?.value?.trim(),
             email: document.getElementById('cliente-email')?.value?.trim(),
             telefono: document.getElementById('cliente-telefono')?.value?.trim(),
-            documento: document.getElementById('cliente-documento')?.value?.trim(),
+            dni: docTipo === 'dni' ? dni : null,
+            pasaporte: docTipo === 'pasaporte' ? pasaporte : null,
+            dni_expiracion: docTipo === 'dni' ? document.getElementById('cliente-dni-expiracion')?.value : null,
+            pasaporte_expiracion: docTipo === 'pasaporte' ? document.getElementById('cliente-pasaporte-expiracion')?.value : null,
             vendedor_id: parseInt(document.getElementById('vendedor-select-nts')?.value),
             esExistente: VentasModule.currentVenta.cliente.esExistente || false,
             id: VentasModule.currentVenta.cliente.id || null
         },
         venta: {
             vendedor_id: parseInt(document.getElementById('vendedor-select-nts')?.value),
-            fecha_venta: new Date().toISOString().split('T')[0],
+            fecha_venta: document.getElementById('fecha-venta')?.value,
             fecha_viaje_inicio: document.getElementById('fecha-viaje-inicio')?.value,
             fecha_viaje_fin: document.getElementById('fecha-viaje-fin')?.value,
             total_final: total,
@@ -917,7 +1073,10 @@ async function crearVentaEnDB(ventaData) {
                     nombre: ventaData.cliente.nombre,
                     email: ventaData.cliente.email,
                     telefono: ventaData.cliente.telefono,
-                    documento: ventaData.cliente.documento,
+                    DNI: ventaData.cliente.dni,
+                    Pasaporte: ventaData.cliente.pasaporte,
+                    dni_expiracion: ventaData.cliente.dni_expiracion,
+                    pasaporte_expiracion: ventaData.cliente.pasaporte_expiracion,
                     vendedor_id: ventaData.cliente.vendedor_id
                 })
                 .select()
@@ -946,29 +1105,50 @@ async function crearVentaEnDB(ventaData) {
         // 4. Crear servicios (solo para vuelos, puedes expandir para otros)
         for (const servicio of ventaData.servicios) {
             if (servicio.tipo === 'vuelo') {
-                const { error: servicioError } = await supabase
+                const { data: vuelo, error: servicioError } = await supabase
                     .from('venta_vuelos')
                     .insert({
                         venta_id: nuevaVenta.id,
                         descripcion: servicio.descripcion,
-                        origen: servicio.origen,
-                        destino: servicio.destino,
                         tipo_itinerario: servicio.tipo_itinerario,
-                        aerolinea: servicio.aerolinea,
-                        clase_vuelo: servicio.clase_vuelo,
                         pasajeros: servicio.pasajeros,
-                        fecha_hora_salida: servicio.fecha_hora_salida,
-                        fecha_hora_llegada: servicio.fecha_hora_llegada,
-                        fecha_hora_regreso: servicio.fecha_hora_regreso,
-                        fecha_hora_llegada_regreso: servicio.fecha_hora_llegada_regreso,
-                        precio_venta: servicio.precio_venta,
                         precio_costo: servicio.precio_costo,
-                        proveedor_id: servicio.proveedor_id,
-                        itinerario_observaciones: servicio.itinerario_observaciones
-                    });
-                
+                        precio_venta: servicio.precio_venta,
+                        margen_ganancia: servicio.precio_venta - servicio.precio_costo,
+                        monto_pagado: 0,
+                        saldo_pendiente_servicio: servicio.precio_costo,
+                        estado_pago_servicio: 'no_pagado',
+                        tiempo_total_vuelo: servicio.tiempo_total_vuelo || null,
+                        cantidad_escalas: servicio.cantidad_escalas || 0,
+                        tiene_escalas: servicio.tiene_escalas || false,
+                        proveedor_id: servicio.proveedor_id || null
+                    })
+                    .select()
+                    .single();
+
                 if (servicioError) {
-                    console.error(`Error creando vuelo:`, servicioError);
+                    console.error(`Error creando vuelo:`, servicioError.message, servicioError.details);
+                } else if (servicio.segmentos && servicio.segmentos.length) {
+                    const segmentos = servicio.segmentos.map(seg => ({
+                        venta_vuelo_id: vuelo.id,
+                        numero_segmento: seg.numero_segmento,
+                        aeropuerto_origen: seg.aeropuerto_origen,
+                        aeropuerto_destino: seg.aeropuerto_destino,
+                        fecha_hora_salida_local: seg.fecha_hora_salida_local,
+                        fecha_hora_llegada_local: seg.fecha_hora_llegada_local,
+                        aerolinea: seg.aerolinea || null,
+                        numero_vuelo: seg.numero_vuelo || null,
+                        tiene_escala: seg.tiene_escala,
+                        aeropuerto_escala: seg.escalas[0]?.aeropuerto || null,
+                        duracion_escala: seg.escalas[0]?.duracion || null
+                    }));
+
+                    const { error: segError } = await supabase
+                        .from('vuelo_segmentos')
+                        .insert(segmentos);
+                    if (segError) {
+                        console.error('Error creando segmentos:', segError.message, segError.details);
+                    }
                 }
             }
         }
@@ -997,17 +1177,23 @@ async function crearVentaLocal(ventaData) {
 // ===== FUNCIONES DE UTILIDAD =====
 function limpiarFormularioCompleto() {
     // Limpiar campos de cliente
-    ['cliente-nombre', 'cliente-email', 'cliente-telefono', 'cliente-documento'].forEach(id => {
+    ['cliente-nombre', 'cliente-email', 'cliente-telefono', 'cliente-dni', 'cliente-pasaporte', 'cliente-dni-expiracion', 'cliente-pasaporte-expiracion'].forEach(id => {
         const field = document.getElementById(id);
         if (field) field.value = '';
     });
+
+    const docTipo = document.getElementById('cliente-doc-tipo');
+    if (docTipo) {
+        docTipo.value = 'dni';
+        toggleDocumentoFields('dni');
+    }
     
     // Limpiar vendedor
     const vendedorSelect = document.getElementById('vendedor-select-nts');
     if (vendedorSelect) vendedorSelect.selectedIndex = 0;
     
     // Limpiar fechas y observaciones
-    ['fecha-viaje-inicio', 'fecha-viaje-fin', 'observaciones-venta'].forEach(id => {
+    ['fecha-venta', 'fecha-viaje-inicio', 'fecha-viaje-fin', 'observaciones-venta'].forEach(id => {
         const field = document.getElementById(id);
         if (field) field.value = '';
     });
@@ -1081,3 +1267,4 @@ window.limpiarFormulario = limpiarFormularioCompleto;
 window.eliminarServicio = eliminarServicio;
 
 console.log('✅ Módulo de ventas completo sin duplicados cargado correctamente');
+console.log('✅ Correcciones para escalas y búsqueda de clientes implementadas');


### PR DESCRIPTION
## Summary
- Allow editing of entire sales by loading client, trip, services and flight segments into the multi-step form
- Add edit controls for individual services and persist changes to Supabase or local storage
- Style service action buttons and update logic to replace related service records when a sale is saved
- Load existing flight services and their segments when editing a sale

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_68a10e3f6a2083289841b108a35e7717