### PR TITLE
fix: sync Supabase config

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -143,8 +143,8 @@ const APP_CONFIG = {
 // ===== EXPORT GLOBAL =====
 window.NTS_CONFIG = {
     // Core
-    supabase,
-    isSupabaseConnected,
+    get supabase() { return supabase; },
+    get isSupabaseConnected() { return isSupabaseConnected; },
     ENUMS,
     APP_CONFIG,
     

--- a/js/main.js
+++ b/js/main.js
@@ -88,20 +88,12 @@ class NTSApp {
 
   async initSupabase() {
     try {
-      if (typeof window.supabase !== 'undefined') {
-        AppState.supabase = window.supabase.createClient(
-          APP_CONFIG.supabase.url,
-          APP_CONFIG.supabase.key
-        );
-        
-        // Test connection
-        const { data, error } = await AppState.supabase.auth.getSession();
-        
-        if (!error || error.message.includes('session_not_found')) {
-          AppState.isConnected = true;
-          console.log('✅ Supabase conectado');
-          this.updateConnectionStatus(true);
-        }
+      const { supabase, isSupabaseConnected } = window.NTS_CONFIG || {};
+      if (supabase && isSupabaseConnected) {
+        AppState.supabase = supabase;
+        AppState.isConnected = true;
+        console.log('✅ Supabase conectado');
+        this.updateConnectionStatus(true);
       } else {
         console.log('⚠️ Supabase no disponible');
         this.updateConnectionStatus(false);


### PR DESCRIPTION
## Summary
- use getters to keep Supabase client and connection status current
- pull Supabase client in `main.js` from global config to avoid stale references

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a25915d59c8328b553e7f64fe929e6