### PR TITLE
fix: sync Supabase config

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -143,8 +143,8 @@ const APP_CONFIG = {
 // ===== EXPORT GLOBAL =====
 window.NTS_CONFIG = {
     // Core
-    supabase,
-    isSupabaseConnected,
+    get supabase() { return supabase; },
+    get isSupabaseConnected() { return isSupabaseConnected; },
     ENUMS,
     APP_CONFIG,
     

--- a/js/main.js
+++ b/js/main.js
@@ -51,6 +51,14 @@ class NTSApp {
     this.init();
   }
 
+  get supabase() {
+    return AppState.supabase;
+  }
+
+  get isSupabaseConnected() {
+    return AppState.isConnected;
+  }
+
   async init() {
     try {
       console.log('🔧 Inicializando aplicación...');
@@ -88,20 +96,12 @@ class NTSApp {
 
   async initSupabase() {
     try {
-      if (typeof window.supabase !== 'undefined') {
-        AppState.supabase = window.supabase.createClient(
-          APP_CONFIG.supabase.url,
-          APP_CONFIG.supabase.key
-        );
-        
-        // Test connection
-        const { data, error } = await AppState.supabase.auth.getSession();
-        
-        if (!error || error.message.includes('session_not_found')) {
-          AppState.isConnected = true;
-          console.log('✅ Supabase conectado');
-          this.updateConnectionStatus(true);
-        }
+      const { supabase, isSupabaseConnected } = window.NTS_CONFIG || {};
+      if (supabase && isSupabaseConnected) {
+        AppState.supabase = supabase;
+        AppState.isConnected = true;
+        console.log('✅ Supabase conectado');
+        this.updateConnectionStatus(true);
       } else {
         console.log('⚠️ Supabase no disponible');
         this.updateConnectionStatus(false);

--- a/js/modules/clientes.js
+++ b/js/modules/clientes.js
@@ -47,7 +47,7 @@ async function initClientesModule() {
 
 // ===== CARGAR DATOS =====
 async function loadClientesData() {
-    const { supabase, isSupabaseConnected } = window.NTS_CONFIG || {};
+    const { supabase, isSupabaseConnected } = window.app || {};
     if (!isSupabaseConnected || !supabase) {
         console.log('⚠️ Supabase no disponible - usando datos demo');
         loadMockClientesData();
@@ -571,7 +571,7 @@ async function saveCliente() {
         const clienteData = getClienteFormData();
         if (!validateClienteData(clienteData)) return;
         window.app?.showLoader('Guardando cliente...');
-        const { supabase, isSupabaseConnected } = window.NTS_CONFIG || {};
+        const { supabase, isSupabaseConnected } = window.app || {};
         if (!isSupabaseConnected || !supabase) {
             throw new Error('Supabase no disponible');
         }
@@ -622,7 +622,7 @@ function validateClienteData(data) {
 }
 
 async function createClienteInDB(data) {
-    const { supabase } = window.NTS_CONFIG || {};
+    const { supabase } = window.app || {};
     if (!supabase) throw new Error('Supabase no disponible');
     const { data: nuevo, error } = await supabase.from('clientes').insert(data).select().single();
     if (error || !nuevo) throw error || new Error('No se pudo crear cliente');
@@ -630,7 +630,7 @@ async function createClienteInDB(data) {
 }
 
 async function updateClienteInDB(data) {
-    const { supabase } = window.NTS_CONFIG || {};
+    const { supabase } = window.app || {};
     const { error } = await supabase.from('clientes').update(data).eq('id', data.id);
     if (error) throw error;
     const idx = ClientesModule.clientes.findIndex(c => c.id === data.id);


### PR DESCRIPTION
## Summary
- expose Supabase client and connection status via NTSApp getters
- have clientes module use the main app's Supabase connection instead of the config wrapper

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a25915d59c8328b553e7f64fe929e6